### PR TITLE
0.2.2: ship content_types/ in wheel, scaffold sample content, fix Windows emoji crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ pip install deepagents-printshop
 
 This installs the Python package and CLI entry point (`printshop`). You still need system dependencies (TeX Live, Poppler) for PDF compilation — see [SYSTEM_DEPS.md](https://github.com/kormco/deepagents-printshop/blob/main/SYSTEM_DEPS.md).
 
+**Sample content:** the wheel ships the `content_types/` definitions and a text-only copy of `artifacts/sample_content/` (markdown + CSV). On first run, `printshop --content <type>` scaffolds the sample into your CWD if it isn't already there, and downloads any missing images from this GitHub repo. Pass `--skip-image-download` to skip the network fetch (figures will reference missing files), or set `PRINTSHOP_IMAGES_REF=<branch-or-tag>` to pin to a specific repo ref.
+
 ### From Source
 
 ```bash

--- a/agents/qa_orchestrator/agent.py
+++ b/agents/qa_orchestrator/agent.py
@@ -323,7 +323,7 @@ class QAOrchestratorAgent:
                 learner = PatternLearner(document_type=self.content_source)
                 learner.learn_from_pipeline_run(results)
             except Exception as e:
-                print(f"⚠️  Pattern learning failed (non-fatal): {e}")
+                print(f"[warn] Pattern learning failed (non-fatal): {e}")
 
         print("=" * 70)
         print(f"QA ORCHESTRATOR: Pipeline {workflow_id} Complete")
@@ -572,11 +572,23 @@ def main():
     """Run the QA orchestrator agent."""
     import argparse
 
+    # Force UTF-8 on stdout/stderr so emoji prints don't crash on Windows cp1252.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
     parser = argparse.ArgumentParser(description='QA Orchestrator Agent')
     parser.add_argument(
         '--content', '-c',
         default='research_report',
         help='Content source folder (e.g., research_report, magazine)'
+    )
+    parser.add_argument(
+        '--skip-image-download',
+        action='store_true',
+        help='Skip auto-downloading sample images from GitHub on first scaffold'
     )
     args = parser.parse_args()
 
@@ -589,6 +601,14 @@ def main():
     print(f"Content source: {content_source}")
     print(f"Run ID: {run_id}")
     print(f"Output directory: {output_dir}")
+
+    # Scaffold sample content from packaged copy if user's CWD is empty.
+    from tools.sample_content_scaffold import ensure_sample_content
+    try:
+        ensure_sample_content(content_source, download_images=not args.skip_image_download)
+    except FileNotFoundError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
 
     # Initialize agent with content source
     agent = QAOrchestratorAgent(content_source=content_source)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "deepagents-printshop"
-version = "0.2.1"
+version = "0.2.2"
 description = "Multi-agent LaTeX document generation with LangGraph QA pipeline"
 readme = "README.md"
 license = "Apache-2.0"
@@ -53,7 +53,22 @@ Homepage = "https://github.com/kormco/deepagents-printshop"
 Repository = "https://github.com/kormco/deepagents-printshop"
 
 [tool.hatch.build.targets.wheel]
-packages = ["agents", "tools"]
+# Ship content_types/ (required for non-default content types to render correctly)
+# and sample_content/ text files only. Images are downloaded on first run by
+# tools/sample_content_scaffold.py to keep wheel size small.
+only-include = [
+    "agents",
+    "tools",
+    "content_types",
+    "artifacts/sample_content",
+]
+exclude = [
+    "*.pdf",
+    "*.png",
+    "*.jpg",
+    "*.jpeg",
+    "**/__pycache__/**",
+]
 
 [tool.hatch.build.targets.sdist]
 exclude = [

--- a/tools/sample_content_scaffold.py
+++ b/tools/sample_content_scaffold.py
@@ -1,0 +1,124 @@
+"""
+Sample Content Scaffold
+
+When the pipeline is run from a directory that does not have
+`artifacts/sample_content/<content_source>/` set up, this helper copies the
+packaged sample content (text files only) into the user's CWD so the rest of
+the pipeline (which expects CWD-relative paths) can proceed.
+
+Images are not shipped in the wheel to keep package size small. Instead, this
+module downloads them on demand from the GitHub repo on first run. Override the
+ref with the PRINTSHOP_IMAGES_REF env var (defaults to "main").
+"""
+
+import os
+import shutil
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+# Packaged sample content lives next to the `tools/` package — see
+# pyproject.toml [tool.hatch.build.targets.wheel] include patterns.
+PACKAGED_SAMPLE_ROOT = Path(__file__).parent.parent / "artifacts" / "sample_content"
+
+GITHUB_REPO = "kormco/deepagents-printshop"
+DEFAULT_REF = "main"
+
+# Image filenames per content type. Kept here (not in a manifest file) so the
+# scaffold script remains self-contained. Update this when adding/removing
+# sample images in artifacts/sample_content/<type>/images/.
+IMAGE_BUNDLE: Dict[str, List[str]] = {
+    "magazine": [
+        "adoption_chart.png",
+        "cost_comparison.png",
+        "cover-image.jpg",
+        "fake-barcode.png",
+        "framework_comparison.png",
+        "image2.jpg",
+        "image3.png",
+        "image4.jpg",
+        "image5.png",
+        "image6.jpg",
+        "image7.png",
+        "model_performance.png",
+    ],
+    "research_report": [
+        "performance_comparison.png",
+    ],
+    "ieee_conference": [],
+}
+
+
+def ensure_sample_content(content_source: str, download_images: bool = True) -> Path:
+    """Ensure ./artifacts/sample_content/<content_source>/ exists in CWD.
+
+    If the CWD copy is missing, scaffold it from the packaged sample. If
+    download_images is True, also fetches any missing images from GitHub.
+    Returns the resolved CWD path. Raises FileNotFoundError if no sample is
+    available (neither in CWD nor in the package).
+    """
+    cwd_path = Path("artifacts/sample_content") / content_source
+    needs_scaffold = not cwd_path.exists()
+
+    if needs_scaffold:
+        packaged_path = PACKAGED_SAMPLE_ROOT / content_source
+        if not packaged_path.exists():
+            raise FileNotFoundError(
+                f"No sample content found for '{content_source}'. Looked in:\n"
+                f"  - {cwd_path.resolve()} (CWD)\n"
+                f"  - {packaged_path} (packaged)\n"
+                f"Create artifacts/sample_content/{content_source}/ with a config.md "
+                f"and section markdown files, or pick a content type that ships with "
+                f"the package."
+            )
+        cwd_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(packaged_path, cwd_path)
+        print(f"[scaffold] Initialized {cwd_path} from packaged sample.")
+
+    if download_images:
+        _download_missing_images(content_source, cwd_path / "images")
+
+    return cwd_path
+
+
+def _download_missing_images(content_source: str, images_dir: Path) -> None:
+    """Download any images listed in IMAGE_BUNDLE that aren't already on disk."""
+    expected = IMAGE_BUNDLE.get(content_source, [])
+    if not expected:
+        return
+
+    images_dir.mkdir(parents=True, exist_ok=True)
+    missing = [name for name in expected if not (images_dir / name).exists()]
+    if not missing:
+        return
+
+    ref = os.environ.get("PRINTSHOP_IMAGES_REF", DEFAULT_REF)
+    base_url = (
+        f"https://raw.githubusercontent.com/{GITHUB_REPO}/{ref}/"
+        f"artifacts/sample_content/{content_source}/images"
+    )
+    print(f"[scaffold] Downloading {len(missing)} sample image(s) for '{content_source}' from {GITHUB_REPO}@{ref}...")
+
+    failures = []
+    for name in missing:
+        url = f"{base_url}/{name}"
+        target = images_dir / name
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "deepagents-printshop-scaffold"})
+            with urllib.request.urlopen(req, timeout=30) as resp, open(target, "wb") as fh:
+                shutil.copyfileobj(resp, fh)
+            print(f"  ok  {name} ({target.stat().st_size:,} bytes)")
+        except (urllib.error.URLError, OSError) as e:
+            failures.append((name, str(e)))
+            print(f"  err {name}: {e}")
+            if target.exists():
+                target.unlink()
+
+    if failures:
+        print(
+            f"[scaffold] {len(failures)} image(s) failed to download. The pipeline will "
+            f"continue but figures referencing them will be broken. Re-run with network "
+            f"access, or copy them manually from "
+            f"https://github.com/{GITHUB_REPO}/tree/{ref}/artifacts/sample_content/{content_source}/images"
+        )


### PR DESCRIPTION
## Summary

The 0.2.1 PyPI wheel only ships `agents/` and `tools/`, so `content_types/` and `artifacts/sample_content/` are missing in any clean install. The `ContentTypeLoader` silently degrades to `document_class=article` defaults, meaning **`printshop --content magazine` was producing a generic article**, not a magazine. Verified end-to-end before fixing: clean install of 0.2.1 produces `magazine.tex` starting with `\documentclass{article}` + `\title{Research Report}`, with the package's own warning firing 6+ times: *"Content type 'magazine' has ZERO preamble blocks — falling back to default preamble. This is likely a bug."*

This PR bundles three fixes:

- **Ship `content_types/` and sample content text files in the wheel** — switched to `only-include` + `exclude` so all `.md`/`.csv` ship but `.png`/`.jpg` don't. Wheel grows from 39 KB to ~211 KB.
- **`tools/sample_content_scaffold.py`** — on first run in an empty directory, copies the packaged sample into CWD and downloads any missing images from `raw.githubusercontent.com/kormco/deepagents-printshop/<ref>/...` (defaults to `main`, override with `PRINTSHOP_IMAGES_REF`). Pass `--skip-image-download` to opt out.
- **Windows emoji print crash** — `sys.stdout/stderr.reconfigure(encoding="utf-8", errors="replace")` at the top of `main()` so `🔄 🔍 ⚠️` prints in `pattern_learner.py` and elsewhere don't crash on cp1252. Also de-emoji'd the cascading print at `agents/qa_orchestrator/agent.py:326` — that "non-fatal" except handler was itself a re-raise vector because its error message contained `⚠️`.

Bumps version to `0.2.2`.

## Verification

Tested end-to-end in a fresh venv with the locally-built `0.2.2` wheel:
- `ContentTypeLoader.list_types()` returns `['ieee_conference', 'magazine', 'research_report']` (was `[]`)
- `load_type('magazine')` returns 3892-char rendering instructions + 4 LaTeX preamble blocks (was empty)
- Sample content auto-scaffolded into CWD; all 12 magazine images auto-downloaded from GitHub
- `printshop --content magazine` produced `magazine.tex` with the correct magazine preamble: `eso-pic`, `contour`, `lettrine`, `multicol`, `tcolorbox`, `rotating`, `wrapfig` packages + magazine color palette
- `magazine.pdf` compiled successfully
- Zero "ZERO preamble blocks" warnings (was 6+)

## Test plan

- [ ] CI green on the branch
- [ ] `pip install <local 0.2.2 wheel>` in a clean venv outside the repo
- [ ] `printshop --content magazine` produces a magazine.pdf with magazine layout (drop caps, multi-col, etc.)
- [ ] `printshop --content ieee_conference` and `printshop --content research_report` also use their respective content type preambles
- [ ] `--skip-image-download` flag avoids network calls
- [ ] After tag/release, double-check raw.githubusercontent.com URLs resolve (or set `PRINTSHOP_IMAGES_REF=v0.2.2` in tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)