### PR TITLE
Make visual QA optional, add /printshop-review skill (#12)

### DIFF
--- a/.claude/skills/printshop-review/SKILL.md
+++ b/.claude/skills/printshop-review/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: printshop-review
+description: Use when the user invokes /printshop-review, asks to "review the printshop output", or wants to walk page-by-page through a deepagents-printshop run and decide which visual fixes to apply. Drives an interactive visual QA loop on a rendered PDF — render pages, propose targeted fixes, accept/reject each, edit the .tex, recompile, repeat. Activate only inside a deepagents-printshop project (artifacts/output/ must exist).
+license: Apache-2.0
+metadata:
+  project: deepagents-printshop
+  pairs_with: VISUAL_QA_MODE=interactive
+allowed-tools: Read, Edit, Write, Bash, Glob
+---
+
+# printshop-review — interactive visual QA for deepagents-printshop
+
+This skill replaces the autonomous `visual_qa` pipeline stage with a **human-in-the-loop** review of the rendered PDF. The pipeline produced the `.tex` and PDF; you walk the user through them page-by-page and apply only the fixes they accept.
+
+## When to activate
+
+- User runs `/printshop-review [run_id]`.
+- User asks to review or QA a printshop run, e.g. "review the output", "let's go through the resume PDF", "QA my latest run".
+
+Only activate inside a deepagents-printshop project (the cwd or a parent has `artifacts/output/`). Otherwise tell the user this skill needs that directory and stop.
+
+## Inputs you'll find on disk
+
+A run lives at `artifacts/output/<run_id>/` and contains:
+
+- `<content_source>.tex` — the LaTeX source the LaTeX-specialist agent generated (e.g. `resume.tex`, `magazine.tex`, `research_report.tex`).
+- `<content_source>.pdf` — the compiled PDF.
+- `handoff.json` — present when `VISUAL_QA_MODE=interactive` was set on the run. Contains run id, tex/pdf paths, page count, and concerns the LaTeX stage flagged.
+
+A `handoff.json` looks like:
+
+```json
+{
+  "run_id": "abc12345",
+  "content_source": "resume",
+  "tex_path": "/path/to/artifacts/output/abc12345/resume.tex",
+  "pdf_path": "/path/to/artifacts/output/abc12345/resume.pdf",
+  "tex_exists": true,
+  "pdf_exists": true,
+  "page_count": 2,
+  "visual_qa_mode": "interactive",
+  "next_step": "interactive_review",
+  "concerns": ["typography: bad spacing on page 2", "weak typography score: 15/25"]
+}
+```
+
+If `handoff.json` is missing (a run produced under `auto` or `disabled` mode), proceed anyway — discover the .tex/PDF directly and skip the concerns hint.
+
+## The review loop
+
+1. **Locate the run.**
+   - If the user passed a `run_id`, use `artifacts/output/<run_id>/`.
+   - Otherwise list newest-first directories under `artifacts/output/`. Pick the most-recent and confirm with the user before proceeding ("Review run abc12345 (resume, 2 pages, 4 minutes ago)?").
+
+2. **Read context.** Read `handoff.json` if present and `<content_source>.tex` (always). Note the concerns from the manifest — they're hints, not commands.
+
+3. **Render the PDF to per-page PNGs.** Use `pdftoppm`:
+   ```bash
+   pdftoppm -png -r 150 <pdf_path> <run_dir>/page
+   ```
+   This produces `<run_dir>/page-1.png`, `page-2.png`, etc. (Use `-r 200` for dense layouts where 150 dpi looks fuzzy.)
+
+4. **Walk pages one at a time.** For each page:
+   - Read the rendered PNG.
+   - Identify *targeted* visual issues — overflow, misaligned figures, table widths, label collisions, awkward spacing, orphan headings, broken citations. Skip nitpicks the user clearly doesn't care about.
+   - For each issue, propose a concrete fix referencing the `.tex` line/region. Show the user the smallest possible diff.
+   - Wait for accept / reject / "explain" / "ask follow-up". Don't apply anything they didn't accept.
+   - Apply accepted fixes with the Edit tool.
+
+5. **Recompile after each batch of accepted fixes.**
+   ```bash
+   python3 -m tools.recompile <run_id>
+   ```
+   This wraps `PDFCompiler` so you get the same multi-pass + regex-fix behavior as the pipeline, and refreshes `handoff.json` with the new page count.
+
+6. **Re-render and continue.** Run `pdftoppm` again, compare the affected page to the previous version, then move to the next page (or revisit if the fix didn't land cleanly).
+
+7. **Stop when the user says "ship it"** (or equivalent). Print a one-line summary: pages reviewed, fixes applied, recompile count.
+
+## Rules of engagement
+
+- **The human is the gate.** No fix gets applied without explicit user accept. Don't batch-apply "obvious" fixes silently.
+- **Surface, don't pile.** Surface 1–3 issues per page max. If a page has more, ask the user if they want to keep going or move on.
+- **Preserve the preamble.** Edit the body. If a fix needs a new package, propose it explicitly and let the user accept the preamble change separately.
+- **Don't rewrite the document.** This is QA, not authoring. If the user wants a major restructure, route them to re-run the full pipeline.
+- **No silent recompiles.** The user should always know when you're invoking pdflatex.
+- **If recompile fails after a fix:** show the error, offer to revert the last edit, and ask before retrying.
+
+## Common fix patterns
+
+See `references/fix-patterns.md` for the catalogue of typical issues (overflow, table widths, figure placement, citation style, etc.) and the small targeted edits that resolve each.
+
+## What this skill is NOT
+
+- Not a content editor — don't propose prose changes; that's the content-editor stage.
+- Not an authoring tool — don't generate new sections or restructure.
+- Not a deploy tool — "ship it" just means stop the loop. The user takes the PDF wherever it goes next.

--- a/.claude/skills/printshop-review/references/fix-patterns.md
+++ b/.claude/skills/printshop-review/references/fix-patterns.md
@@ -1,0 +1,67 @@
+# Common visual QA fix patterns
+
+Reference catalogue for the `printshop-review` skill. Load on demand.
+
+## Overflow / `Overfull \hbox`
+
+**Symptom:** text or table runs into the right margin; visible bleed in the rendered PNG.
+
+**Fix candidates (smallest first):**
+- Add a soft hyphen at a sensible break: `\-` inside the offending word.
+- Wrap the run in `\sloppy ... \fussy` if it's confined to one paragraph.
+- Convert a long URL or path to use `\url{...}` (requires `\usepackage{url}`).
+- For tables: switch the offending column to `p{<width>}` or `m{<width>}`.
+
+Don't reach for `\setlength{\emergencystretch}` unless several paragraphs are affected — it changes spacing globally.
+
+## Tables wider than the text block
+
+**Fix candidates:**
+- Wrap the tabular in `\resizebox{\textwidth}{!}{...}` (requires `graphicx`).
+- Convert to `tabularx` with `X` columns for fluid widths.
+- Reduce inter-column padding: `\setlength{\tabcolsep}{4pt}` *inside* the table only — restore afterward.
+- For data tables specifically, drop a column or merge two columns rather than shrinking type.
+
+## Figures placed wrong
+
+**Symptom:** figure floats far from its reference, leaves a near-empty page, or splits a section.
+
+**Fix candidates:**
+- Tighten the placement specifier: `\begin{figure}[!htbp]` instead of `[h]`.
+- Force a placement with `\FloatBarrier` (requires `placeins`) before the next section.
+- For small inline figures, use `wrapfigure` (requires `wrapfig`).
+
+Avoid `[H]` (`float` package) unless the user explicitly asks for "exactly here" — it usually looks worse.
+
+## Caption / label issues
+
+- Caption *below* a figure, *above* a table — flip if reversed.
+- Duplicate `\label{}` produces a `multiply defined labels` warning. Find the duplicate via grep and rename one.
+- `\ref{??}` in the rendered PDF means a missing label — recompile twice (the pipeline already does this; if it still shows, the label is genuinely absent).
+
+## Headings on the wrong page
+
+**Symptom:** a section heading sits at the bottom of a page with its body on the next.
+
+**Fix candidates:**
+- `\nopagebreak[4]` immediately after the heading (gentle hint).
+- `\needspace{4\baselineskip}` before the heading (requires `needspace`).
+- For real wrap-up: add a `\pagebreak` *before* the heading.
+
+## Inconsistent spacing around lists / code blocks
+
+- Reduce list separation: `\setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}` inside the list (or use `enumitem`'s `noitemsep`).
+- For code blocks (`verbatim` / `lstlisting`), surrounding blank-line whitespace is structural — strip an extra blank line in the source before/after the block.
+
+## Citation / bibliography style mismatch
+
+- If the bib style doesn't match the content type (e.g. IEEE numeric vs APA author-year), change `\bibliographystyle{...}`. Don't hand-edit individual `\cite` calls.
+- `[1, 2, 3]` rendering as `[1][2][3]` usually means a missing `cite` package — add `\usepackage{cite}`.
+
+## When to stop fixing
+
+Three signals it's time to stop:
+
+1. The user has accepted nothing on the last 2–3 issues.
+2. Each fix reveals a new issue of similar magnitude (the document is fundamentally fighting the template — re-run the pipeline with a different content type).
+3. Recompile fails twice in a row from the same fix family.

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,10 @@ OPENAI_API_KEY=your_openai_api_key_here
 
 # Optional: Tavily API key for web search functionality
 TAVILY_API_KEY=your_tavily_api_key_here
+
+# Visual QA mode — controls whether the pipeline runs autonomous Claude-vision review
+#   auto         (default) Run all three stages, including autonomous visual QA
+#   disabled     Stop after LaTeX generation; emit PDF + report, no visual QA
+#   interactive  Stop after LaTeX generation and write a handoff manifest;
+#                run /printshop-review in Claude Code to drive the visual review yourself
+VISUAL_QA_MODE=auto

--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,10 @@ env/
 # DeepAgents
 .deepagents/
 
-# Claude Code
-.claude/
+# Claude Code (project-level skills under .claude/skills/ are tracked;
+# everything else under .claude/ — settings.local.json, etc. — is local-only)
+.claude/*
+!.claude/skills/
 
 # LaTeX
 *.aux

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,20 @@ DeepAgents persistent memory stored in `.deepagents/`:
 
 **Environment**: Uses `.env` file for ANTHROPIC_API_KEY, Docker volumes for persistence.
 
+### Visual QA Modes
+
+`VISUAL_QA_MODE` (env var, default `auto`) controls whether the pipeline runs the autonomous visual QA stage:
+
+| Mode | Pipeline behavior | Visual QA |
+|------|-------------------|-----------|
+| `auto` | Runs all three stages | Claude vision, automated, gated |
+| `disabled` | Stops after LaTeX gen, emits PDF + report | Skipped |
+| `interactive` | Stops after LaTeX gen, writes `handoff.json` | Skipped — user runs `/printshop-review` in Claude Code to drive a human-in-the-loop review |
+
+In `interactive` mode the orchestrator writes `artifacts/output/<run_id>/handoff.json` listing the .tex/PDF paths, page count, and any concerns the LaTeX-specialist stage flagged. The `.claude/skills/printshop-review/` skill picks that up. Recompilation after a fix goes through `python -m tools.recompile <run_id>`, which wraps `PDFCompiler` so multi-pass + regex fixes still apply.
+
+Routing for `disabled`/`interactive` skips both `enrich_for_visual_qa` and `visual_qa`; `iteration` and `escalation` still apply when the LaTeX gate fails (e.g., compilation errors), so the only change is the post-pass branch.
+
 ## Development Patterns
 
 ### Adding New Content Types

--- a/README.md
+++ b/README.md
@@ -635,6 +635,29 @@ Uses multimodal LLM analysis for PDF quality:
 - Figure and table quality
 - **Critical:** LaTeX syntax detection (flags unrendered LaTeX commands)
 
+### Visual QA Modes
+
+The autonomous visual QA stage is the most expensive and most Claude-dependent part of the pipeline. The `VISUAL_QA_MODE` env var lets you opt out and either ship straight after LaTeX generation or drive the visual review yourself in Claude Code:
+
+| Mode | Pipeline behavior | Visual QA |
+|------|-------------------|-----------|
+| `auto` *(default)* | Runs all three stages | Claude vision, automated, gated |
+| `disabled` | Stops after LaTeX gen, emits PDF + report | Skipped — review manually or out-of-band |
+| `interactive` | Stops after LaTeX gen, writes a handoff manifest | Skipped — invoke `/printshop-review` in Claude Code to walk page-by-page through the rendered PDF |
+
+```bash
+# Run without autonomous visual QA
+VISUAL_QA_MODE=disabled python agents/qa_orchestrator/agent.py
+
+# Run, then drive the review yourself in Claude Code
+VISUAL_QA_MODE=interactive python agents/qa_orchestrator/agent.py
+# ... then in Claude Code: /printshop-review
+```
+
+In `interactive` mode the pipeline writes `artifacts/output/<run_id>/handoff.json` (run id, .tex/PDF paths, page count, concerns from the LaTeX stage). The `.claude/skills/printshop-review/` skill picks that up and runs an interactive review loop — render pages, propose targeted fixes, accept/reject, recompile, continue.
+
+Recompilation after a skill-applied fix goes through `python -m tools.recompile <run_id>`, which wraps `PDFCompiler` to keep multi-pass behavior and regex-fix support consistent with the autonomous pipeline.
+
 ## Version Control System
 
 All content versions are tracked with complete change history:

--- a/agents/qa_orchestrator/langgraph_workflow.py
+++ b/agents/qa_orchestrator/langgraph_workflow.py
@@ -6,6 +6,7 @@ downstream agents directly -- no WorkflowExecution object, no glue code.
 PipelineState is the single source of truth.
 """
 
+import json
 import operator
 import os
 import sys
@@ -29,6 +30,29 @@ from agents.qa_orchestrator.quality_gates import (  # noqa: E402, I001
 )
 from agents.qa_orchestrator.pipeline_types import AgentResult, AgentType  # noqa: E402, I001
 from agents.qa_orchestrator.workflow_coordinator import WorkflowCoordinator  # noqa: E402, I001
+
+
+# ---------------------------------------------------------------------------
+# Visual QA mode helpers
+# ---------------------------------------------------------------------------
+
+VISUAL_QA_MODES = ("auto", "disabled", "interactive")
+
+
+def get_visual_qa_mode() -> str:
+    """Read VISUAL_QA_MODE from the environment, defaulting to "auto".
+
+    Unknown values fall back to "auto" with a warning so a typo never silently
+    disables the autonomous review.
+    """
+    raw = (os.environ.get("VISUAL_QA_MODE") or "auto").strip().lower()
+    if raw not in VISUAL_QA_MODES:
+        print(
+            f"   [LangGraph] VISUAL_QA_MODE={raw!r} not recognized; falling back to 'auto'. "
+            f"Valid values: {', '.join(VISUAL_QA_MODES)}"
+        )
+        return "auto"
+    return raw
 
 
 # ---------------------------------------------------------------------------
@@ -682,8 +706,91 @@ def iteration_node(state: PipelineState) -> Dict[str, Any]:
     }
 
 
+def _count_pdf_pages(pdf_path: Path) -> Optional[int]:
+    """Best-effort PDF page count. Returns None if no available reader works."""
+    try:
+        from pdf2image.pdf2image import pdfinfo_from_path  # type: ignore
+        info = pdfinfo_from_path(str(pdf_path))
+        pages = info.get("Pages")
+        if pages is not None:
+            return int(pages)
+    except Exception:
+        pass
+    try:
+        from pypdf import PdfReader  # type: ignore
+        return len(PdfReader(str(pdf_path)).pages)
+    except Exception:
+        pass
+    return None
+
+
+def write_handoff_manifest(state: PipelineState) -> Optional[Path]:
+    """Write handoff.json for the interactive review skill to pick up.
+
+    Lists where the .tex/PDF live, page count, and any concerns the
+    LaTeX-specialist stage flagged. Returns the manifest path, or None if
+    the output directory could not be resolved.
+    """
+    output_dir = state.get("output_dir")
+    if not output_dir:
+        return None
+
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    content_source = state.get("content_source", "research_report")
+    tex_path = out_path / f"{content_source}.tex"
+    pdf_path = out_path / f"{content_source}.pdf"
+
+    page_count: Optional[int] = None
+    if pdf_path.exists():
+        page_count = _count_pdf_pages(pdf_path)
+
+    agent_ctx = state.get("agent_context", {}) or {}
+    latex_notes = agent_ctx.get("latex_specialist_notes", {}) or {}
+    concerns: List[str] = []
+    for issue in latex_notes.get("typography_issues", []) or []:
+        concerns.append(f"typography: {issue}")
+    typography_score = latex_notes.get("typography_score")
+    if typography_score is not None and typography_score < 20:
+        concerns.append(f"weak typography score: {typography_score}/25")
+    structure_score = latex_notes.get("structure_score")
+    if structure_score is not None and structure_score < 22:
+        concerns.append(f"weak structure score: {structure_score}/25")
+
+    manifest = {
+        "run_id": state.get("workflow_id"),
+        "timestamp": datetime.now().isoformat(),
+        "content_source": content_source,
+        "tex_path": str(tex_path),
+        "pdf_path": str(pdf_path),
+        "tex_exists": tex_path.exists(),
+        "pdf_exists": pdf_path.exists(),
+        "page_count": page_count,
+        "visual_qa_mode": get_visual_qa_mode(),
+        "next_step": "interactive_review",
+        "concerns": concerns,
+    }
+
+    manifest_path = out_path / "handoff.json"
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+    return manifest_path
+
+
 def completion_node(state: PipelineState) -> Dict[str, Any]:
-    """Mark pipeline as successfully complete."""
+    """Mark pipeline as successfully complete.
+
+    In interactive mode, also writes a handoff.json so the
+    /printshop-review Claude Code skill can pick up where the pipeline
+    stopped.
+    """
+    if get_visual_qa_mode() == "interactive":
+        manifest_path = write_handoff_manifest(state)
+        if manifest_path is not None:
+            print(f"   [LangGraph] Wrote interactive handoff manifest: {manifest_path}")
+            print("   [LangGraph] Run /printshop-review in Claude Code to drive the visual review.")
+
     return {
         "success": True,
         "human_handoff": True,
@@ -725,8 +832,16 @@ def route_after_content_review(state: PipelineState) -> Literal["enrich_for_late
         return "escalation"
 
 
-def route_after_latex_optimization(state: PipelineState) -> Literal["enrich_for_visual_qa", "iteration", "escalation"]:
-    """Decide next step after LaTeX optimization using quality gate."""
+def route_after_latex_optimization(
+    state: PipelineState,
+) -> Literal["enrich_for_visual_qa", "quality_assessment", "iteration", "escalation"]:
+    """Decide next step after LaTeX optimization using quality gate.
+
+    When VISUAL_QA_MODE is "disabled" or "interactive", a passing LaTeX gate
+    routes directly to quality_assessment, skipping the autonomous visual QA
+    stage. Iteration / escalation behavior is unchanged so compilation
+    failures still drive a fix loop.
+    """
     coordinator = WorkflowCoordinator(
         content_source=state.get("content_source", "research_report")
     )
@@ -736,7 +851,11 @@ def route_after_latex_optimization(state: PipelineState) -> Literal["enrich_for_
     print(f"   [LangGraph] LaTeX quality gate: {evaluation.result.value} (score={evaluation.score})")
 
     if evaluation.result == QualityGateResult.PASS:
-        return "enrich_for_visual_qa"
+        mode = get_visual_qa_mode()
+        if mode == "auto":
+            return "enrich_for_visual_qa"
+        print(f"   [LangGraph] VISUAL_QA_MODE={mode} — skipping autonomous visual QA")
+        return "quality_assessment"
     elif evaluation.result == QualityGateResult.ITERATE:
         if state.get("iterations_completed", 0) >= coordinator.quality_gate_manager.thresholds.max_iterations:
             return "escalation"

--- a/tests/test_langgraph_workflow.py
+++ b/tests/test_langgraph_workflow.py
@@ -3,6 +3,8 @@
 All tests run without Docker, TeX Live, or API keys.
 """
 
+import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -13,11 +15,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from agents.qa_orchestrator.langgraph_workflow import (  # noqa: E402, I001
     build_qa_graph,
     compile_qa_pipeline,
+    completion_node,
     export_mermaid_diagram,
+    get_visual_qa_mode,
     merge_dicts,
     route_after_content_review,
     route_after_latex_optimization,
     route_after_quality_assessment,
+    write_handoff_manifest,
 )
 from agents.qa_orchestrator.quality_gates import (  # noqa: E402
     QualityAssessment,
@@ -494,6 +499,181 @@ class TestCompilationFailureFeedback:
         evaluation = manager.evaluate_latex_quality_gate(assessment)
         assert evaluation.result == QualityGateResult.ITERATE
         assert "compilation failed" in evaluation.reasons[0].lower()
+
+
+class TestVisualQAMode:
+    def test_default_is_auto(self, monkeypatch):
+        monkeypatch.delenv("VISUAL_QA_MODE", raising=False)
+        assert get_visual_qa_mode() == "auto"
+
+    def test_disabled_recognized(self, monkeypatch):
+        monkeypatch.setenv("VISUAL_QA_MODE", "disabled")
+        assert get_visual_qa_mode() == "disabled"
+
+    def test_interactive_recognized(self, monkeypatch):
+        monkeypatch.setenv("VISUAL_QA_MODE", "interactive")
+        assert get_visual_qa_mode() == "interactive"
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("VISUAL_QA_MODE", "Interactive")
+        assert get_visual_qa_mode() == "interactive"
+
+    def test_unknown_falls_back_to_auto(self, monkeypatch):
+        monkeypatch.setenv("VISUAL_QA_MODE", "manual")
+        assert get_visual_qa_mode() == "auto"
+
+    @patch("agents.qa_orchestrator.langgraph_workflow.WorkflowCoordinator")
+    def test_route_latex_pass_routes_to_quality_assessment_when_disabled(
+        self, MockCoordinator, monkeypatch
+    ):
+        """When VISUAL_QA_MODE=disabled, a passing LaTeX gate skips visual_qa."""
+        monkeypatch.setenv("VISUAL_QA_MODE", "disabled")
+        mock_coord = MagicMock()
+        mock_coord.assess_workflow_quality.return_value = QualityAssessment(
+            latex_score=90, latex_issues=[]
+        )
+        mock_coord.quality_gate_manager.evaluate_latex_quality_gate.return_value = QualityGateEvaluation(
+            gate_name="latex_quality",
+            result=QualityGateResult.PASS,
+            score=90,
+            threshold=85,
+            reasons=["Good LaTeX quality: 90"],
+            recommendations=[],
+            next_action="proceed_to_visual_qa",
+        )
+        MockCoordinator.return_value = mock_coord
+
+        state = {
+            "content_source": "research_report",
+            "agent_results": [],
+            "quality_assessments": [],
+            "quality_evaluations": [],
+            "iterations_completed": 0,
+            "agent_context": {},
+        }
+        assert route_after_latex_optimization(state) == "quality_assessment"
+
+    @patch("agents.qa_orchestrator.langgraph_workflow.WorkflowCoordinator")
+    def test_route_latex_pass_routes_to_quality_assessment_when_interactive(
+        self, MockCoordinator, monkeypatch
+    ):
+        """When VISUAL_QA_MODE=interactive, a passing LaTeX gate skips visual_qa."""
+        monkeypatch.setenv("VISUAL_QA_MODE", "interactive")
+        mock_coord = MagicMock()
+        mock_coord.assess_workflow_quality.return_value = QualityAssessment(
+            latex_score=90, latex_issues=[]
+        )
+        mock_coord.quality_gate_manager.evaluate_latex_quality_gate.return_value = QualityGateEvaluation(
+            gate_name="latex_quality",
+            result=QualityGateResult.PASS,
+            score=90,
+            threshold=85,
+            reasons=["Good LaTeX quality: 90"],
+            recommendations=[],
+            next_action="proceed_to_visual_qa",
+        )
+        MockCoordinator.return_value = mock_coord
+
+        state = {
+            "content_source": "research_report",
+            "agent_results": [],
+            "quality_assessments": [],
+            "quality_evaluations": [],
+            "iterations_completed": 0,
+            "agent_context": {},
+        }
+        assert route_after_latex_optimization(state) == "quality_assessment"
+
+    @patch("agents.qa_orchestrator.langgraph_workflow.WorkflowCoordinator")
+    def test_iteration_still_takes_priority_in_disabled_mode(
+        self, MockCoordinator, monkeypatch
+    ):
+        """Disabled mode does NOT skip the iteration path on a failing gate."""
+        monkeypatch.setenv("VISUAL_QA_MODE", "disabled")
+        mock_coord = MagicMock()
+        mock_coord.assess_workflow_quality.return_value = QualityAssessment(latex_score=70)
+        mock_coord.quality_gate_manager.evaluate_latex_quality_gate.return_value = QualityGateEvaluation(
+            gate_name="latex_quality",
+            result=QualityGateResult.ITERATE,
+            score=70,
+            threshold=85,
+            reasons=[],
+            recommendations=[],
+            next_action="run_latex_specialist",
+        )
+        mock_coord.quality_gate_manager.thresholds.max_iterations = 3
+        MockCoordinator.return_value = mock_coord
+
+        state = {
+            "content_source": "research_report",
+            "agent_results": [],
+            "quality_assessments": [],
+            "quality_evaluations": [],
+            "iterations_completed": 0,
+            "agent_context": {},
+        }
+        assert route_after_latex_optimization(state) == "iteration"
+
+
+class TestHandoffManifest:
+    def test_handoff_written_in_interactive_mode(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VISUAL_QA_MODE", "interactive")
+        # Create a fake .tex so the manifest reports tex_exists=True
+        (tmp_path / "research_report.tex").write_text("\\documentclass{article}\n")
+        state = {
+            "workflow_id": "abc12345",
+            "content_source": "research_report",
+            "output_dir": str(tmp_path),
+            "agent_context": {
+                "latex_specialist_notes": {
+                    "structure_score": 24,
+                    "typography_score": 15,  # weak — should appear in concerns
+                    "typography_issues": ["bad spacing on page 2"],
+                    "packages_used": [],
+                }
+            },
+        }
+        completion_node(state)
+
+        manifest_path = tmp_path / "handoff.json"
+        assert manifest_path.exists(), "handoff.json should be written in interactive mode"
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["run_id"] == "abc12345"
+        assert manifest["content_source"] == "research_report"
+        assert manifest["visual_qa_mode"] == "interactive"
+        assert manifest["next_step"] == "interactive_review"
+        assert manifest["tex_exists"] is True
+        assert manifest["pdf_exists"] is False  # no PDF written
+        # Concerns surface the typography issue and the weak score
+        assert any("typography" in c for c in manifest["concerns"])
+        assert any("weak typography" in c for c in manifest["concerns"])
+
+    def test_handoff_not_written_in_auto_mode(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VISUAL_QA_MODE", "auto")
+        state = {
+            "workflow_id": "abc12345",
+            "content_source": "research_report",
+            "output_dir": str(tmp_path),
+            "agent_context": {},
+        }
+        completion_node(state)
+        assert not (tmp_path / "handoff.json").exists()
+
+    def test_handoff_not_written_in_disabled_mode(self, tmp_path, monkeypatch):
+        """Disabled mode emits no manifest — user has nothing to pick up."""
+        monkeypatch.setenv("VISUAL_QA_MODE", "disabled")
+        state = {
+            "workflow_id": "abc12345",
+            "content_source": "research_report",
+            "output_dir": str(tmp_path),
+            "agent_context": {},
+        }
+        completion_node(state)
+        assert not (tmp_path / "handoff.json").exists()
+
+    def test_write_handoff_manifest_returns_none_without_output_dir(self, monkeypatch):
+        monkeypatch.setenv("VISUAL_QA_MODE", "interactive")
+        assert write_handoff_manifest({}) is None
 
 
 class TestMergeDicts:

--- a/tests/test_langgraph_workflow.py
+++ b/tests/test_langgraph_workflow.py
@@ -4,7 +4,6 @@ All tests run without Docker, TeX Live, or API keys.
 """
 
 import json
-import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/tests/test_recompile.py
+++ b/tests/test_recompile.py
@@ -1,0 +1,84 @@
+"""Tests for tools.recompile — the skill's PDF recompile entrypoint.
+
+Tests cover discovery and handoff manifest refresh; actual pdflatex invocation
+is mocked so the suite stays portable.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools import recompile  # noqa: E402
+
+
+class TestResolveRunDir:
+    def test_accepts_explicit_directory(self, tmp_path):
+        assert recompile.resolve_run_dir(str(tmp_path)) == tmp_path.resolve()
+
+    def test_rejects_missing_run(self):
+        with pytest.raises(FileNotFoundError):
+            recompile.resolve_run_dir("definitely-does-not-exist-1234")
+
+
+class TestDiscoverTexFile:
+    def test_picks_only_tex_file(self, tmp_path):
+        (tmp_path / "resume.tex").write_text("\\documentclass{article}\n")
+        assert recompile.discover_tex_file(tmp_path, None).name == "resume.tex"
+
+    def test_skips_fix_candidates(self, tmp_path):
+        (tmp_path / "resume.tex").write_text("\\documentclass{article}\n")
+        (tmp_path / "resume.fix1.tex").write_text("garbage")
+        assert recompile.discover_tex_file(tmp_path, None).name == "resume.tex"
+
+    def test_requires_explicit_source_when_ambiguous(self, tmp_path):
+        (tmp_path / "resume.tex").write_text("a")
+        (tmp_path / "magazine.tex").write_text("b")
+        with pytest.raises(RuntimeError):
+            recompile.discover_tex_file(tmp_path, None)
+
+    def test_explicit_source_picks_match(self, tmp_path):
+        (tmp_path / "resume.tex").write_text("a")
+        (tmp_path / "magazine.tex").write_text("b")
+        assert recompile.discover_tex_file(tmp_path, "magazine").name == "magazine.tex"
+
+
+class TestUpdateHandoff:
+    def test_no_op_when_manifest_missing(self, tmp_path):
+        recompile.update_handoff(tmp_path, tmp_path / "x.pdf")
+        assert not (tmp_path / "handoff.json").exists()
+
+    def test_refreshes_pdf_state(self, tmp_path):
+        manifest_path = tmp_path / "handoff.json"
+        manifest_path.write_text(json.dumps({"pdf_exists": False, "pdf_path": ""}))
+        pdf_path = tmp_path / "resume.pdf"
+        pdf_path.write_bytes(b"%PDF-1.4 fake")
+
+        with patch.object(recompile, "count_pdf_pages", return_value=2):
+            recompile.update_handoff(tmp_path, pdf_path)
+
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["pdf_exists"] is True
+        assert manifest["page_count"] == 2
+        assert "last_recompile" in manifest
+
+
+class TestRecompileFlow:
+    def test_calls_compiler_and_returns_pdf_path(self, tmp_path):
+        tex_path = tmp_path / "resume.tex"
+        tex_path.write_text("\\documentclass{article}\n\\begin{document}hi\\end{document}\n")
+
+        with patch("tools.recompile.PDFCompiler") as MockCompiler:
+            MockCompiler.return_value.compile.return_value = (True, "ok")
+            success, message, pdf = recompile.recompile(
+                str(tmp_path), content_source="resume", update_handoff_manifest=False
+            )
+
+        assert success is True
+        assert message == "ok"
+        assert pdf == tmp_path / "resume.pdf"
+        MockCompiler.assert_called_once_with(output_dir=str(tmp_path.resolve()))

--- a/tools/recompile.py
+++ b/tools/recompile.py
@@ -1,0 +1,166 @@
+"""Recompile a printshop run's .tex file to PDF.
+
+Used by the /printshop-review Claude Code skill after the user accepts a fix.
+Wraps PDFCompiler so the skill never has to drive pdflatex directly and gets
+the same multi-pass + regex-fix behavior as the autonomous pipeline.
+
+Usage:
+    python -m tools.recompile <run_id_or_dir> [--content-source NAME] [--update-handoff]
+    python -m tools.recompile artifacts/output/abc12345
+    python -m tools.recompile abc12345 --content-source resume
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Tuple
+
+# Make the project root importable when invoked as `python tools/recompile.py`
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.pdf_compiler import PDFCompiler  # noqa: E402
+
+
+def resolve_run_dir(run_id_or_dir: str) -> Path:
+    """Accept either a run_id (e.g. abc12345) or a path under artifacts/output/."""
+    candidate = Path(run_id_or_dir)
+    if candidate.is_dir():
+        return candidate.resolve()
+    default = PROJECT_ROOT / "artifacts" / "output" / run_id_or_dir
+    if default.is_dir():
+        return default.resolve()
+    raise FileNotFoundError(
+        f"Could not locate run directory for {run_id_or_dir!r}. "
+        f"Tried {candidate} and {default}."
+    )
+
+
+def discover_tex_file(run_dir: Path, content_source: Optional[str]) -> Path:
+    """Find the .tex file to compile inside a run directory."""
+    if content_source:
+        explicit = run_dir / f"{content_source}.tex"
+        if explicit.exists():
+            return explicit
+        raise FileNotFoundError(f"{explicit} does not exist")
+
+    tex_files = sorted(run_dir.glob("*.tex"))
+    # Skip throwaway candidate fixes like research_report.fix1.tex
+    tex_files = [p for p in tex_files if ".fix" not in p.stem]
+    if not tex_files:
+        raise FileNotFoundError(f"No .tex files in {run_dir}")
+    if len(tex_files) > 1:
+        names = ", ".join(p.name for p in tex_files)
+        raise RuntimeError(
+            f"Multiple .tex files in {run_dir} ({names}). "
+            f"Pass --content-source to disambiguate."
+        )
+    return tex_files[0]
+
+
+def count_pdf_pages(pdf_path: Path) -> Optional[int]:
+    """Best-effort page count, or None if no reader is available."""
+    try:
+        from pdf2image.pdf2image import pdfinfo_from_path  # type: ignore
+
+        return int(pdfinfo_from_path(str(pdf_path)).get("Pages", 0)) or None
+    except Exception:
+        pass
+    try:
+        from pypdf import PdfReader  # type: ignore
+
+        return len(PdfReader(str(pdf_path)).pages)
+    except Exception:
+        return None
+
+
+def update_handoff(run_dir: Path, pdf_path: Path) -> None:
+    """Refresh page count + timestamp in handoff.json if it exists."""
+    manifest_path = run_dir / "handoff.json"
+    if not manifest_path.exists():
+        return
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"warn: could not update {manifest_path}: {e}")
+        return
+
+    manifest["pdf_exists"] = pdf_path.exists()
+    manifest["pdf_path"] = str(pdf_path)
+    if pdf_path.exists():
+        manifest["page_count"] = count_pdf_pages(pdf_path)
+    manifest["last_recompile"] = datetime.now().isoformat()
+
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+
+
+def recompile(
+    run_id_or_dir: str,
+    content_source: Optional[str] = None,
+    update_handoff_manifest: bool = True,
+) -> Tuple[bool, str, Path]:
+    """Recompile the .tex inside the given run directory.
+
+    Returns (success, message, pdf_path).
+    """
+    run_dir = resolve_run_dir(run_id_or_dir)
+    tex_path = discover_tex_file(run_dir, content_source)
+    pdf_path = tex_path.with_suffix(".pdf")
+
+    compiler = PDFCompiler(output_dir=str(run_dir))
+    success, message = compiler.compile(str(tex_path))
+
+    if update_handoff_manifest:
+        update_handoff(run_dir, pdf_path)
+
+    return success, message, pdf_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Recompile a printshop run's .tex to PDF.",
+    )
+    parser.add_argument(
+        "run",
+        help="Run id (e.g. abc12345) or path to a run directory under artifacts/output/.",
+    )
+    parser.add_argument(
+        "--content-source",
+        default=None,
+        help="Override the .tex stem (e.g. 'resume', 'magazine'). "
+        "Auto-detected when only one .tex file is present.",
+    )
+    parser.add_argument(
+        "--no-update-handoff",
+        dest="update_handoff",
+        action="store_false",
+        help="Skip refreshing handoff.json after a successful recompile.",
+    )
+    args = parser.parse_args()
+
+    try:
+        success, message, pdf_path = recompile(
+            args.run,
+            content_source=args.content_source,
+            update_handoff_manifest=args.update_handoff,
+        )
+    except (FileNotFoundError, RuntimeError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    if success:
+        print(f"PDF compiled: {pdf_path}")
+        return 0
+    print(f"compilation failed: {message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #12.

## Summary

Adds `VISUAL_QA_MODE` env var with three modes — `auto` (default, unchanged), `disabled`, and `interactive` — and a new `/printshop-review` Claude Code skill for the human-in-the-loop alternative.

| Mode | Pipeline behavior | Visual QA |
|------|-------------------|-----------|
| `auto` *(default)* | Runs all three stages | Claude vision, automated, gated |
| `disabled` | Stops after LaTeX gen, emits PDF + report | Skipped |
| `interactive` | Stops after LaTeX gen, writes `handoff.json` | Skipped — invoke `/printshop-review` in Claude Code to drive page-by-page review |

## How the routing changes

`route_after_latex_optimization` now branches on `VISUAL_QA_MODE`. `disabled` and `interactive` skip both `enrich_for_visual_qa` and `visual_qa`, going straight to `quality_assessment`. Iteration / escalation paths are untouched, so compilation failures still drive the existing fix loop.

## What's in the box

- `agents/qa_orchestrator/langgraph_workflow.py` — mode helper, conditional routing, `completion_node` writes `artifacts/output/<run_id>/handoff.json` (run id, .tex/PDF paths, page count, latex-stage concerns) when mode=interactive.
- `tools/recompile.py` — thin CLI the skill calls after applying a fix: `python -m tools.recompile <run_id>`. Wraps `PDFCompiler` so multi-pass + regex fixes still apply, refreshes `handoff.json` with the new page count.
- `.claude/skills/printshop-review/` — new Claude Code skill in standard SKILL.md frontmatter format. Body describes the review loop (locate run → render pages → propose targeted fixes → accept/reject → recompile → repeat). `references/fix-patterns.md` catalogues common targeted edits (overflow, table widths, figure placement, citation style, etc.).
- `.gitignore` — tracks `.claude/skills/` while keeping `.claude/settings.local.json` local-only.
- `.env.example`, `CLAUDE.md`, `README.md` — document the three modes and the skill workflow.

## Tests

21 new tests covering:
- `get_visual_qa_mode` (default, recognized values, case insensitive, fallback on typo)
- routing in `disabled` and `interactive` modes (skips visual QA on PASS)
- iteration/escalation still take priority on a failing LaTeX gate
- handoff manifest contents (run id, paths, concerns, page count)
- handoff written only in interactive mode
- recompile discovery (single tex, fix-candidate skip, ambiguous, explicit override)
- handoff refresh after recompile

`python3 -m pytest tests/ -v` → **80 passed** (59 prior + 21 new).

## Test plan

- [x] Unit tests for routing in each mode
- [x] Unit tests for handoff manifest structure
- [x] Unit tests for recompile entrypoint discovery + handoff refresh
- [ ] Manual: run `VISUAL_QA_MODE=disabled python agents/qa_orchestrator/agent.py` end-to-end and confirm pipeline stops after LaTeX gen
- [ ] Manual: run `VISUAL_QA_MODE=interactive python agents/qa_orchestrator/agent.py`, confirm `handoff.json` is written, then invoke `/printshop-review` in Claude Code on the run
- [ ] Manual: confirm `python -m tools.recompile <run_id>` produces a PDF and updates `handoff.json`

## Out of scope

Issue #7 (migrating all of `content_types/*/type.md` and `.deepagents/*/memories/` to the SKILL.md pattern with `SkillsMiddleware`) stays separate. This PR only borrows the SKILL.md *format* for the new Claude-Code-targeted skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)