### PR TITLE
Drop unused deepagents-cli dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-DeepAgents PrintShop is a document generation system that produces professional LaTeX documents with comprehensive formatting, citations, tables, images, and diagrams. It uses the DeepAgents CLI framework, LangGraph for pipeline orchestration, and runs in Docker with TeX Live for PDF compilation.
+DeepAgents PrintShop is a document generation system that produces professional LaTeX documents with comprehensive formatting, citations, tables, images, and diagrams. It uses LangGraph for pipeline orchestration, the Anthropic SDK for Claude calls, and runs in Docker with TeX Live for PDF compilation.
 
 **Important: Do not hardcode LaTeX output into deterministic Python logic.** Rendering behavior is controlled by natural language instructions in `content_types/*/type.md` files, which the LaTeX agent reads at generation time. To change how a document looks (disclaimers, footers, spacing, section formatting), edit the type.md rendering instructions — not the Python code.
 
@@ -234,7 +234,6 @@ Example: `gh issue create --title "..." --body "..." --label "bug"`
 ## Dependencies
 
 Python packages (requirements.txt):
-- deepagents-cli: Core agent framework
 - anthropic, openai: LLM APIs
 - langchain, langchain-anthropic, langchain-openai: LLM orchestration
 - langgraph: Pipeline state graph orchestration

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/kormco/deepagents-printshop/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org)
 [![Built with LangGraph](https://img.shields.io/badge/Built%20with-LangGraph-orange.svg)](https://github.com/langchain-ai/langgraph)
-[![Built with DeepAgents CLI](https://img.shields.io/badge/Built%20with-DeepAgents%20CLI-purple.svg)](https://pypi.org/project/deepagents-cli/)
 
 An advanced multi-agent system that generates professional LaTeX documents with comprehensive quality assurance, LLM-based document optimization, and automated visual quality analysis. Orchestrated by a **LangGraph StateGraph** with quality gates, iterative refinement, and inter-agent communication.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -36,7 +36,7 @@ docker-compose build
 This will:
 - Install Python 3.11
 - Install TeX Live (for LaTeX/PDF generation)
-- Install deepagents-cli and all dependencies
+- Install Python dependencies (LangGraph, Anthropic SDK, etc.)
 - Set up the project structure
 
 ### 3. Run the Agent
@@ -188,16 +188,6 @@ If you get authentication errors:
 
 ## Advanced Usage
 
-### Running with DeepAgents CLI
-
-Once inside the container, you can use the full DeepAgents CLI:
-
-```bash
-docker-compose run --rm deepagent-scribe bash
-# Inside container:
-deepagents --agent research-scribe
-```
-
 ### Inspecting Agent Memory
 
 Agent memories are stored in `.deepagents/research_agent/memories/`:
@@ -227,7 +217,7 @@ result = tool.process()
 
 ## Resources
 
-- DeepAgents Documentation: https://docs.langchain.com/oss/python/deepagents
+- LangGraph Documentation: https://langchain-ai.github.io/langgraph/
 - LaTeX Documentation: https://www.latex-project.org/help/documentation/
 - TikZ Examples: https://texample.net/tikz/
 - Anthropic API: https://docs.anthropic.com/

--- a/agents/research_agent/agent.py
+++ b/agents/research_agent/agent.py
@@ -2,7 +2,6 @@
 DeepAgents PrintShop - Research Agent
 
 A specialized agent for generating LaTeX research reports with persistent memory.
-Integrates with DeepAgents CLI framework.
 """
 
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "deepagents-cli",
     "anthropic",
     "openai",
     "tavily-python",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-deepagents-cli
 anthropic
 openai
 tavily-python


### PR DESCRIPTION
## Summary

`deepagents-cli` is listed in `requirements.txt` and `pyproject.toml` but never actually imported anywhere in the codebase. Confirmed via `grep -rn "deepagents" --include="*.py"` — all hits are filesystem paths like `.deepagents/<agent>/memories/`, which is a project naming convention, not a use of the SDK or CLI.

`deepagents-cli` is a **TUI/terminal frontend** (think Claude Code or Cursor for deepagents), not a Python library. It exposes no importable API. A headless LangGraph pipeline run via `python agents/qa_orchestrator/agent.py` has no surface for the CLI to attach to.

## What changes

- **`requirements.txt`** — drop `deepagents-cli`
- **`pyproject.toml`** — drop `deepagents-cli` from `dependencies`
- **`README.md`** — drop the misleading `Built with DeepAgents CLI` badge (the LangGraph badge stays — that's accurate)
- **`CLAUDE.md`** — correct the project overview ("uses the DeepAgents CLI framework" → "uses LangGraph for pipeline orchestration, the Anthropic SDK for Claude calls"); drop the inaccurate dependency bullet
- **`SETUP.md`** — drop the "Running with DeepAgents CLI" advanced section (which referenced a `research-scribe` agent that doesn't exist in this project); fix the install line; replace the DeepAgents-docs resource link with the LangGraph one
- **`agents/research_agent/agent.py`** — drop the misleading "Integrates with DeepAgents CLI framework" docstring line

## Net diff

```
 CLAUDE.md                      |  3 +--
 README.md                      |  1 -
 SETUP.md                       | 14 ++------------
 agents/research_agent/agent.py |  1 -
 pyproject.toml                 |  1 -
 requirements.txt               |  1 -
 6 files changed, 3 insertions(+), 18 deletions(-)
```

## Note on issue #7

If we later want `SkillsMiddleware` or `create_deep_agent` (issue #7), the right dep to add is **`deepagents`** (the SDK) — it's a separate PyPI package from `deepagents-cli`. This PR doesn't preempt that decision; it just stops shipping a dep we don't use.

## Test plan

- [x] `python3 -m pytest tests/` — 80 passed
- [x] `ruff check .` — clean
- [x] `grep -rn "deepagents-cli\|DeepAgents CLI\|deepagents_cli" --include="*.py" --include="*.md" --include="*.txt" --include="*.toml" --include="*.yml"` — zero hits after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)