### PR TITLE
Add opt-in LangSmith tracing for pipeline runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,11 @@ TAVILY_API_KEY=your_tavily_api_key_here
 #   interactive  Stop after LaTeX generation and write a handoff manifest;
 #                run /printshop-review in Claude Code to drive the visual review yourself
 VISUAL_QA_MODE=auto
+
+# Optional: LangSmith tracing for pipeline runs (free tier covers ~5k traces/mo).
+# When LANGCHAIN_TRACING_V2=true, LangGraph nodes auto-trace and direct
+# Anthropic SDK calls get wrapped via tools/tracing.py. Leave unset (or "false")
+# to disable — there is no behavior change when tracing is off.
+# LANGCHAIN_TRACING_V2=true
+# LANGCHAIN_API_KEY=lsv2_pt_...
+# LANGCHAIN_PROJECT=deepagents-printshop

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,14 @@ DeepAgents persistent memory stored in `.deepagents/`:
 
 **Environment**: Uses `.env` file for ANTHROPIC_API_KEY, Docker volumes for persistence.
 
+### LangSmith Tracing (optional)
+
+When `LANGCHAIN_TRACING_V2=true` is set (plus `LANGCHAIN_API_KEY` and `LANGCHAIN_PROJECT`), every pipeline run is traced to LangSmith. Cost, per-node latency, prompts, and model usage are all visible per run.
+
+LangGraph nodes auto-instrument. Direct `anthropic.Anthropic()` clients do not — `tools/tracing.py` wraps them via `maybe_wrap_anthropic()` so their `messages.create` calls also appear in the trace tree. Tracing is fully opt-in: with the env var unset, `maybe_wrap_anthropic` returns the client unchanged and `langsmith` isn't even imported.
+
+When adding a new direct `anthropic.Anthropic(...)` instantiation, wrap it with `maybe_wrap_anthropic(...)` so it shows up in traces when tracing is enabled. `langchain-anthropic`'s `ChatAnthropic` is already auto-instrumented and needs no wrapping.
+
 ### Visual QA Modes
 
 `VISUAL_QA_MODE` (env var, default `auto`) controls whether the pipeline runs the autonomous visual QA stage:

--- a/README.md
+++ b/README.md
@@ -634,6 +634,18 @@ Uses multimodal LLM analysis for PDF quality:
 - Figure and table quality
 - **Critical:** LaTeX syntax detection (flags unrendered LaTeX commands)
 
+### LangSmith Tracing (optional)
+
+The pipeline makes 10–20 Claude calls per run across multiple stages. To get cost / latency / prompt visibility per run, enable LangSmith tracing:
+
+```bash
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_API_KEY=lsv2_pt_...
+LANGCHAIN_PROJECT=deepagents-printshop
+```
+
+LangGraph nodes auto-trace. Direct Anthropic SDK calls are wrapped via `tools/tracing.maybe_wrap_anthropic`. Tracing is fully opt-in — with the env var unset, the wrapper is a no-op and there's zero overhead.
+
 ### Visual QA Modes
 
 The autonomous visual QA stage is the most expensive and most Claude-dependent part of the pipeline. The `VISUAL_QA_MODE` env var lets you opt out and either ship straight after LaTeX generation or drive the visual review yourself in Claude Code:

--- a/agents/content_editor/content_reviewer.py
+++ b/agents/content_editor/content_reviewer.py
@@ -16,6 +16,8 @@ from anthropic import Anthropic
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
+from tools.tracing import maybe_wrap_anthropic  # noqa: E402
+
 try:
     from tools.pattern_injector import PatternInjector
 except ImportError:
@@ -32,7 +34,7 @@ class ContentReviewer:
         Args:
             document_type: Type of document for loading type-specific patterns
         """
-        self.client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+        self.client = maybe_wrap_anthropic(Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY")))
         self.document_type = document_type
 
         # Initialize pattern injector if available

--- a/agents/latex_specialist/latex_optimizer.py
+++ b/agents/latex_specialist/latex_optimizer.py
@@ -20,6 +20,7 @@ if str(project_root) not in __import__('sys').path:
 
 from tools.content_type_loader import ContentTypeLoader
 from tools.latex_generator import LaTeXGenerator
+from tools.tracing import maybe_wrap_anthropic
 
 
 class LaTeXOptimizer:
@@ -42,7 +43,7 @@ class LaTeXOptimizer:
         self.content_source = content_source
         self.content_dir = Path("artifacts/sample_content") / content_source
         self.api_key = os.getenv('ANTHROPIC_API_KEY')
-        self.client = anthropic.Anthropic(api_key=self.api_key) if self.api_key else None
+        self.client = maybe_wrap_anthropic(anthropic.Anthropic(api_key=self.api_key)) if self.api_key else None
         self.professional_packages = {
             'typography': [
                 '\\usepackage[T1]{fontenc}',

--- a/agents/qa_orchestrator/context_enrichment.py
+++ b/agents/qa_orchestrator/context_enrichment.py
@@ -34,7 +34,9 @@ def _get_anthropic_client():
     if not api_key:
         return None
     from anthropic import Anthropic
-    return Anthropic(api_key=api_key)
+
+    from tools.tracing import maybe_wrap_anthropic
+    return maybe_wrap_anthropic(Anthropic(api_key=api_key))
 
 
 def _load_pattern_context(content_source: str) -> Dict[str, str]:

--- a/agents/qa_orchestrator/langgraph_workflow.py
+++ b/agents/qa_orchestrator/langgraph_workflow.py
@@ -166,7 +166,8 @@ def _llm_fix_latex(tex_content: str, error_log: str, attempt: int) -> Optional[s
     try:
         from anthropic import Anthropic
 
-        client = Anthropic(api_key=api_key)
+        from tools.tracing import maybe_wrap_anthropic
+        client = maybe_wrap_anthropic(Anthropic(api_key=api_key))
 
         if original_preamble:
             prompt = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "langchain-anthropic",
     "langchain-openai",
     "langgraph",
+    "langsmith",
     "pandas",
     "pillow",
     "matplotlib",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ langchain
 langchain-anthropic
 langchain-openai
 langgraph
+langsmith
 pandas
 pillow
 matplotlib

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,86 @@
+"""Tests for tools.tracing — opt-in LangSmith wrapping for Anthropic clients."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools import tracing  # noqa: E402
+
+
+class TestIsTracingEnabled:
+    def test_unset_is_disabled(self, monkeypatch):
+        monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+        assert tracing.is_tracing_enabled() is False
+
+    def test_empty_is_disabled(self, monkeypatch):
+        monkeypatch.setenv("LANGCHAIN_TRACING_V2", "")
+        assert tracing.is_tracing_enabled() is False
+
+    def test_false_is_disabled(self, monkeypatch):
+        monkeypatch.setenv("LANGCHAIN_TRACING_V2", "false")
+        assert tracing.is_tracing_enabled() is False
+
+    def test_true_is_enabled(self, monkeypatch):
+        monkeypatch.setenv("LANGCHAIN_TRACING_V2", "true")
+        assert tracing.is_tracing_enabled() is True
+
+    def test_true_uppercase(self, monkeypatch):
+        monkeypatch.setenv("LANGCHAIN_TRACING_V2", "TRUE")
+        assert tracing.is_tracing_enabled() is True
+
+    def test_one_is_enabled(self, monkeypatch):
+        monkeypatch.setenv("LANGCHAIN_TRACING_V2", "1")
+        assert tracing.is_tracing_enabled() is True
+
+
+class TestMaybeWrapAnthropic:
+    def test_no_op_when_disabled(self, monkeypatch):
+        """The whole point: zero-cost pass-through when tracing is off."""
+        monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+        sentinel = object()
+        assert tracing.maybe_wrap_anthropic(sentinel) is sentinel
+
+    def test_wraps_when_enabled(self, monkeypatch):
+        """When tracing is on, wrap_anthropic gets called and we return its result."""
+        monkeypatch.setenv("LANGCHAIN_TRACING_V2", "true")
+
+        # Inject a fake langsmith.wrappers module so this test doesn't depend on
+        # whether the real package is installed in the test environment.
+        import types
+
+        wrapped_marker = object()
+
+        def fake_wrap(client):
+            assert client is sentinel
+            return wrapped_marker
+
+        fake_wrappers = types.ModuleType("langsmith.wrappers")
+        fake_wrappers.wrap_anthropic = fake_wrap
+        fake_langsmith = types.ModuleType("langsmith")
+        fake_langsmith.wrappers = fake_wrappers
+
+        monkeypatch.setitem(sys.modules, "langsmith", fake_langsmith)
+        monkeypatch.setitem(sys.modules, "langsmith.wrappers", fake_wrappers)
+
+        sentinel = object()
+        assert tracing.maybe_wrap_anthropic(sentinel) is wrapped_marker
+
+    def test_falls_back_when_langsmith_missing(self, monkeypatch):
+        """If tracing is enabled but langsmith isn't installed, return the client unchanged."""
+        monkeypatch.setenv("LANGCHAIN_TRACING_V2", "true")
+
+        # Force the import to fail by inserting a sentinel that raises on attribute access.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "langsmith.wrappers" or name.startswith("langsmith"):
+                raise ImportError("simulated missing langsmith")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        sentinel = object()
+        assert tracing.maybe_wrap_anthropic(sentinel) is sentinel

--- a/tools/llm_latex_generator.py
+++ b/tools/llm_latex_generator.py
@@ -7,6 +7,8 @@ from typing import Dict, List, Optional, Tuple
 
 import anthropic
 
+from tools.tracing import maybe_wrap_anthropic
+
 
 @dataclass
 class LaTeXGenerationRequest:
@@ -51,7 +53,7 @@ class LLMLaTeXGenerator:
         self.api_key = api_key or os.getenv('ANTHROPIC_API_KEY')
         if not self.api_key:
             raise ValueError("ANTHROPIC_API_KEY not found")
-        self.client = anthropic.Anthropic(api_key=self.api_key)
+        self.client = maybe_wrap_anthropic(anthropic.Anthropic(api_key=self.api_key))
 
     def generate_document(self, request: LaTeXGenerationRequest,
                           validate: bool = True) -> LaTeXGenerationResult:

--- a/tools/tracing.py
+++ b/tools/tracing.py
@@ -1,0 +1,39 @@
+"""Optional LangSmith tracing for direct Anthropic SDK calls.
+
+LangGraph nodes auto-trace when ``LANGCHAIN_TRACING_V2=true``. The bare
+``anthropic.Anthropic()`` client does not — wrap it here so direct
+``client.messages.create()`` calls also show up in the trace tree.
+
+Tracing is fully opt-in. If ``LANGCHAIN_TRACING_V2`` is unset/false the
+wrapper is a no-op and the client is returned unmodified, so call sites
+can use ``maybe_wrap_anthropic`` unconditionally without paying a cost
+when tracing is disabled. ``langsmith`` is imported lazily so an unused
+install never pays the import cost either.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def is_tracing_enabled() -> bool:
+    """Return True if ``LANGCHAIN_TRACING_V2`` is set to a truthy value."""
+    return os.environ.get("LANGCHAIN_TRACING_V2", "").strip().lower() in ("true", "1", "yes")
+
+
+def maybe_wrap_anthropic(client: Any) -> Any:
+    """Patch an Anthropic client for LangSmith tracing if enabled.
+
+    No-op when tracing is disabled — returns ``client`` unchanged. Safe
+    to call at every Anthropic client instantiation; the cost when
+    disabled is one env-var lookup.
+    """
+    if not is_tracing_enabled():
+        return client
+    try:
+        from langsmith.wrappers import wrap_anthropic  # lazy import
+    except ImportError:
+        # langsmith not installed — leave the client untouched.
+        return client
+    return wrap_anthropic(client)

--- a/tools/visual_qa.py
+++ b/tools/visual_qa.py
@@ -20,6 +20,8 @@ except ImportError:
     ANTHROPIC_AVAILABLE = False
     print("⚠️ Anthropic not available - visual analysis will be limited")
 
+from tools.tracing import maybe_wrap_anthropic
+
 
 @dataclass
 class VisualValidationResult:
@@ -168,7 +170,7 @@ class MultimodalLLMAnalyzer:
                 print("⚠️ ANTHROPIC_API_KEY not found - using fallback analysis")
                 self.client = None
             else:
-                self.client = anthropic.Anthropic(api_key=self.api_key)
+                self.client = maybe_wrap_anthropic(anthropic.Anthropic(api_key=self.api_key))
 
         self.validation_prompts = self._init_validation_prompts()
 


### PR DESCRIPTION
## Summary

The pipeline makes 10–20 Claude calls per run across 6+ files and currently has zero per-run cost / latency / prompt visibility. This PR adds opt-in LangSmith tracing.

LangGraph nodes auto-trace when `LANGCHAIN_TRACING_V2=true`, but direct `anthropic.Anthropic()` clients (which most call sites use) do not. The fix is a thin wrapper.

## What changes

**New `tools/tracing.py`** with two functions:
- `is_tracing_enabled()` — reads `LANGCHAIN_TRACING_V2` (truthy: `true`/`1`/`yes`)
- `maybe_wrap_anthropic(client)` — pass-through when tracing is off; routes through `langsmith.wrappers.wrap_anthropic` when on. `langsmith` is imported lazily so disabled tracing pays no import cost.

**Every `anthropic.Anthropic(...)` instantiation wrapped:**
- `agents/qa_orchestrator/context_enrichment.py` (3 Haiku enrichment calls)
- `agents/qa_orchestrator/langgraph_workflow.py` (LLM LaTeX repair)
- `agents/content_editor/content_reviewer.py`
- `agents/latex_specialist/latex_optimizer.py`
- `tools/llm_latex_generator.py` (6 generation calls)
- `tools/visual_qa.py` (vision analysis)

**Deps:** `langsmith` was already transitively pulled in via `langchain-core`. Promoted to an explicit dep in `pyproject.toml` + `requirements.txt` since we use it directly.

**Docs:** `.env.example` documents the 3 tracing env vars as optional. CLAUDE.md and README each get a brief "LangSmith Tracing (optional)" section explaining the opt-in flow.

## Opt-in semantics

Tracing is fully opt-in. With `LANGCHAIN_TRACING_V2` unset (the default), `maybe_wrap_anthropic` returns the client unchanged and `langsmith` isn't imported. **Behavior is identical to before.** Verified by tests for the disabled, enabled, and missing-langsmith fallback paths.

## Test plan

- [x] `python3 -m pytest tests/` — 89 passed (80 prior + 9 new)
- [x] `ruff check .` — clean
- [x] Manual: confirm pipeline runs unchanged with tracing off
- [ ] Manual: set the 3 env vars on a real run and confirm a trace shows up in LangSmith with all 6 wrapped clients visible as nested spans

## Net diff

```
 .env.example                                 |  8 ++++++
 CLAUDE.md                                    |  8 ++++++
 README.md                                    | 12 +++++++
 agents/content_editor/content_reviewer.py    |  4 ++-
 agents/latex_specialist/latex_optimizer.py   |  3 +-
 agents/qa_orchestrator/context_enrichment.py |  4 ++-
 agents/qa_orchestrator/langgraph_workflow.py |  3 +-
 pyproject.toml                               |  1 +
 requirements.txt                             |  1 +
 tools/llm_latex_generator.py                 |  4 ++-
 tools/visual_qa.py                           |  4 ++-
 tests/test_tracing.py                        | 91 +++++++++++++++++++++++
 tools/tracing.py                             | 41 ++++++++++++
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)