### PR TITLE
Add HITL engine CLI behind HITL_MODE flag

### DIFF
--- a/agents/qa_orchestrator/langgraph_workflow.py
+++ b/agents/qa_orchestrator/langgraph_workflow.py
@@ -56,6 +56,22 @@ def get_visual_qa_mode() -> str:
 
 
 # ---------------------------------------------------------------------------
+# HITL (human-in-the-loop) mode helpers
+# ---------------------------------------------------------------------------
+
+def get_hitl_mode() -> bool:
+    """Read HITL_MODE from the environment.
+
+    When "on", the graph pauses at human-checkpoint nodes via interrupt() so
+    an external driver (the printshop CLI) can present state to a human and
+    resume with their decision. When "off" (default), the graph runs the
+    existing autonomous routing unchanged.
+    """
+    raw = (os.environ.get("HITL_MODE") or "off").strip().lower()
+    return raw == "on"
+
+
+# ---------------------------------------------------------------------------
 # LLM-based LaTeX error fixer (second-tier, after PDFCompiler regex fixes)
 # ---------------------------------------------------------------------------
 
@@ -707,6 +723,81 @@ def iteration_node(state: PipelineState) -> Dict[str, Any]:
     }
 
 
+def _build_latex_checkpoint_payload(state: PipelineState) -> Dict[str, Any]:
+    """Build the ask payload for the post-LaTeX human checkpoint.
+
+    Lives next to the node so both stay in sync. Pulls paths, scores, and
+    upstream notes from the current PipelineState.
+    """
+    content_source = state.get("content_source", "research_report")
+    output_dir = state.get("output_dir", "artifacts/output")
+
+    agent_results = state.get("agent_results", []) or []
+    latex_results = [r for r in agent_results if r.get("agent_type") == "latex_specialist"]
+    latex_score = latex_results[-1].get("quality_score") if latex_results else None
+
+    agent_ctx = state.get("agent_context", {}) or {}
+    latex_notes = agent_ctx.get("latex_specialist_notes", {}) or {}
+
+    pdf_path = f"{output_dir}/{content_source}.pdf"
+    tex_path = f"{output_dir}/{content_source}.tex"
+
+    return {
+        "stage": "latex_optimization",
+        "iteration": state.get("iterations_completed", 0),
+        "summary": (
+            f"LaTeX stage complete (score {latex_score})."
+            if latex_score is not None
+            else "LaTeX stage complete."
+        ),
+        "scores": {
+            "agent": {"value": latex_score, "rationale": "LaTeX specialist quality score"},
+            "thresholds": {"minimum": 80, "good": 85, "excellent": 90},
+        },
+        "artifacts": {
+            "tex": tex_path,
+            "pdf": pdf_path,
+        },
+        "notes": {
+            "structure_score": latex_notes.get("structure_score"),
+            "typography_score": latex_notes.get("typography_score"),
+            "typography_issues": latex_notes.get("typography_issues", []),
+            "compilation_success": latex_notes.get("compilation_success"),
+        },
+        "question": "Review the compiled output. Approve, edit, describe changes, rerun the stage, skip to finalize, or abort.",
+        "valid_actions": [
+            "approve_all",
+            "approve_subset",
+            "edit",
+            "describe",
+            "rerun_stage",
+            "skip_to_finalize",
+            "abort",
+        ],
+    }
+
+
+def human_checkpoint_after_latex_node(state: PipelineState) -> Dict[str, Any]:
+    """Pause for human review of the LaTeX-optimized output.
+
+    Calls interrupt() with an ask payload built from current state. When the
+    graph is resumed via Command(resume=response), interrupt() returns that
+    response and we record it in agent_context for the routing function.
+
+    Only reached when HITL_MODE=on; route_after_latex_optimization_or_hitl
+    keeps autonomous runs out of this node entirely.
+    """
+    from langgraph.types import interrupt
+
+    payload = _build_latex_checkpoint_payload(state)
+    response = interrupt(payload)
+
+    return {
+        "current_stage": "human_checkpoint_after_latex",
+        "agent_context": {"human_response_after_latex": response or {"action": "approve_all"}},
+    }
+
+
 def _count_pdf_pages(pdf_path: Path) -> Optional[int]:
     """Best-effort PDF page count. Returns None if no available reader works."""
     try:
@@ -865,6 +956,58 @@ def route_after_latex_optimization(
         return "escalation"
 
 
+def route_after_latex_optimization_or_hitl(
+    state: PipelineState,
+) -> Literal[
+    "human_checkpoint_after_latex",
+    "enrich_for_visual_qa",
+    "quality_assessment",
+    "iteration",
+    "escalation",
+]:
+    """Route after latex_optimization, with optional HITL pause.
+
+    When HITL_MODE=on and the LaTeX stage was successful, route to the human
+    checkpoint instead of continuing autonomously. Compilation failures still
+    drive the existing iterate/escalate path so the auto-retry inner loop
+    survives.
+    """
+    if get_hitl_mode():
+        agent_results = state.get("agent_results", []) or []
+        latex_results = [r for r in agent_results if r.get("agent_type") == "latex_specialist"]
+        if latex_results and latex_results[-1].get("success"):
+            print("   [LangGraph] HITL_MODE=on — pausing for human review after LaTeX stage")
+            return "human_checkpoint_after_latex"
+    return route_after_latex_optimization(state)
+
+
+def route_after_human_checkpoint(
+    state: PipelineState,
+) -> Literal["enrich_for_visual_qa", "quality_assessment", "iteration", "completion", "escalation"]:
+    """Route based on the human's response stored in agent_context.
+
+    Mirrors the action vocabulary in printshop/contracts.py. Unknown actions
+    fall through to the same destination as approve_all so the graph never
+    deadlocks on a malformed response.
+    """
+    agent_ctx = state.get("agent_context", {}) or {}
+    response = agent_ctx.get("human_response_after_latex", {}) or {}
+    action = response.get("action", "approve_all")
+
+    if action == "abort":
+        return "escalation"
+    if action == "rerun_stage":
+        return "iteration"
+    if action == "skip_to_finalize":
+        return "completion"
+
+    # approve_all, approve_subset, edit, describe — proceed to next stage
+    mode = get_visual_qa_mode()
+    if mode == "auto":
+        return "enrich_for_visual_qa"
+    return "quality_assessment"
+
+
 def route_after_quality_assessment(state: PipelineState) -> Literal["completion", "iteration", "escalation"]:
     """Decide final outcome after quality assessment."""
     evaluations = state.get("quality_evaluations", [])
@@ -907,6 +1050,11 @@ def build_qa_graph() -> StateGraph:
     graph.add_node("completion", completion_node)
     graph.add_node("escalation", escalation_node)
 
+    # HITL checkpoint — only routed to when HITL_MODE=on. Always present in
+    # the graph (orphan when off) so a single graph definition serves both
+    # autonomous and interactive runs.
+    graph.add_node("human_checkpoint_after_latex", human_checkpoint_after_latex_node)
+
     # Add enrichment nodes
     graph.add_node("enrich_for_latex", enrich_for_latex_node)
     graph.add_node("enrich_for_visual_qa", enrich_for_visual_qa_node)
@@ -916,7 +1064,8 @@ def build_qa_graph() -> StateGraph:
     graph.add_edge(START, "content_review")
     graph.add_conditional_edges("content_review", route_after_content_review)
     graph.add_edge("enrich_for_latex", "latex_optimization")
-    graph.add_conditional_edges("latex_optimization", route_after_latex_optimization)
+    graph.add_conditional_edges("latex_optimization", route_after_latex_optimization_or_hitl)
+    graph.add_conditional_edges("human_checkpoint_after_latex", route_after_human_checkpoint)
     graph.add_edge("enrich_for_visual_qa", "visual_qa")
     graph.add_edge("visual_qa", "quality_assessment")
     graph.add_conditional_edges("quality_assessment", route_after_quality_assessment)

--- a/docs/hitl-engine-handoff.md
+++ b/docs/hitl-engine-handoff.md
@@ -1,0 +1,199 @@
+# HITL Engine — Handoff
+
+**Branch:** `feature/hitl-engine-cli` (`8bedf6e`, pushed to origin)
+**Status:** First commit landed; smoke-tested end-to-end on Windows + MiKTeX with a real `research_report` run.
+**Created:** 2026-05-08
+
+## Why this exists
+
+The autonomous QA pipeline (LangGraph StateGraph in `agents/qa_orchestrator/langgraph_workflow.py`) made every quality decision itself: gate thresholds, iteration caps, when to escalate. In practice the user reviews every output anyway, and the most common failure mode is "score plateaued below threshold → escalated." A human-in-the-loop variant fixes that — the human becomes the gate, the engine just runs stages.
+
+The longer-term goal is to ship the engine as a Docker container and the user-facing flow as a Claude Code plugin (`/printshop`, `/printshop-iterate`). This branch is **only the engine half** — the CLI contract that the plugin will eventually drive. No plugin manifest, no Docker image yet.
+
+The full design discussion that led here is in conversation; the short version: we chose **LangGraph drives, Claude is the UI** (Option 2) over **Claude drives, calls LangGraph subgraphs** (Option 1) because the user wants the engine in Docker so end users don't install Python, TeX Live, etc.
+
+## What's in the commit
+
+Two commits on the branch:
+
+```
+8bedf6e Force UTF-8 stdio in printshop CLI to survive Windows cp1252
+1a760be Add HITL engine CLI scaffolding behind HITL_MODE flag
+```
+
+### New code
+
+- `printshop/__init__.py` — public re-exports
+- `printshop/__main__.py` — `python -m printshop` entry
+- `printshop/cli.py` — `start`, `resume`, `status`, `list`, `abort`, `logs`
+- `printshop/contracts.py` — `SCHEMA_VERSION`, payload builders, `runs_dir()` resolution
+
+### Modified
+
+- `agents/qa_orchestrator/langgraph_workflow.py`
+  - `get_hitl_mode()` — reads `HITL_MODE` env var (default off)
+  - `human_checkpoint_after_latex_node()` — calls `interrupt()` with an ask payload
+  - `route_after_latex_optimization_or_hitl()` — wraps existing routing; only diverts to checkpoint when flag on AND latex stage succeeded (compilation failures still drive auto-retry)
+  - `route_after_human_checkpoint()` — branches on response action
+
+### Tests
+
+48 new tests in `tests/test_hitl_cli.py` covering: HITL flag parsing, routing in both modes, ask-payload shape, response validation, contract envelope helpers, CLI status/list/abort against a tmp runs dir, argparse wiring.
+
+Existing `test_graph_has_10_nodes` bumped to 11 — the new `human_checkpoint_after_latex` node is always present in the graph (orphan when HITL is off) so a single graph definition serves both modes.
+
+**137 total tests pass.** Autonomous behavior is byte-identical when `HITL_MODE=off`.
+
+## How it works at runtime
+
+```
+$ python -m printshop start <run_id> --content-type research_report
+
+  ┌────────────────────────────────────────────────────────────┐
+  │ 1. CLI sets HITL_MODE=on (idempotent), creates run dir,    │
+  │    builds initial PipelineState, opens SqliteSaver         │
+  │ 2. graph.invoke() runs content_review → enrich → latex     │
+  │ 3. Latex stage succeeds → router returns                   │
+  │    "human_checkpoint_after_latex"                          │
+  │ 4. Node calls interrupt(payload) — graph pauses,           │
+  │    state persisted to checkpoint.sqlite                    │
+  │ 5. CLI extracts result["__interrupt__"][0].value,          │
+  │    wraps it in build_ask_envelope, writes ask.json         │
+  │ 6. CLI exits 0 — the run is paused                         │
+  └────────────────────────────────────────────────────────────┘
+
+$ python -m printshop resume <run_id> --response response.json
+
+  ┌────────────────────────────────────────────────────────────┐
+  │ 7. CLI loads response.json, validates action vocabulary    │
+  │ 8. Clears stale ask.json, opens SqliteSaver                │
+  │ 9. graph.invoke(Command(resume=response)) — interrupt()    │
+  │    inside the node returns the response value              │
+  │ 10. Node stores response in agent_context;                 │
+  │     route_after_human_checkpoint reads action and routes   │
+  │ 11. Graph runs to END → CLI writes done.json               │
+  └────────────────────────────────────────────────────────────┘
+```
+
+`/loop /printshop-iterate` (future plugin work) wraps this by polling `printshop status` between fires.
+
+## JSON contracts (the actual cross-system interface)
+
+`schema_version: "1"` everywhere. Files appear in `~/.printshop/runs/<run_id>/` (override with `PRINTSHOP_RUNS_DIR`).
+
+### `ask.json` (engine → driver, present while paused)
+
+```json
+{
+  "schema_version": "1",
+  "run_id": "d4e2aac2",
+  "asked_at": "2026-05-08T13:59:03",
+  "stage": "latex_optimization",
+  "iteration": 1,
+  "summary": "LaTeX stage complete (score 93).",
+  "scores": {
+    "agent": {"value": 93, "rationale": "LaTeX specialist quality score"},
+    "thresholds": {"minimum": 80, "good": 85, "excellent": 90}
+  },
+  "artifacts": {"tex": "...", "pdf": "..."},
+  "notes": {"structure_score": 20, "typography_score": 24, "typography_issues": [], "compilation_success": false},
+  "question": "Review the compiled output...",
+  "valid_actions": ["approve_all", "approve_subset", "edit", "describe", "rerun_stage", "skip_to_finalize", "abort"]
+}
+```
+
+### `response.json` (driver → engine, present briefly during resume)
+
+```json
+{
+  "schema_version": "1",
+  "action": "approve_all",
+  "approved_proposal_ids": [],
+  "rejected_proposal_ids": [],
+  "additional_instructions": "",
+  "human_score": 93,
+  "exit_after_apply": false
+}
+```
+
+### `done.json` / `error.json` (terminal)
+
+```json
+{
+  "schema_version": "1",
+  "run_id": "d4e2aac2",
+  "status": "completed",   // or "escalated" / "failed" / "aborted"
+  "final_artifacts": {"tex": "...", "pdf": "..."},
+  "stages_completed": ["content_editor", "latex_specialist", "visual_qa"],
+  "iterations_completed": 1,
+  "human_checkpoints": 1,
+  "wallclock_seconds": 152.48,
+  "completed_at": "2026-05-08T14:35:07"
+}
+```
+
+`SCHEMA_VERSION` is `"1"`. Any future field shape change bumps it; drivers should refuse runs they don't recognize.
+
+## Smoke test results (run `d4e2aac2`)
+
+| Phase | Time | What happened |
+|---|---|---|
+| `start` | 13:57 | Content edit (iterated 79→80), LaTeX gen, PDF compile to 3 pages |
+| Paused | 13:59 | `ask.json` written with score 93/100, .tex/.pdf paths, valid_actions |
+| `resume` | 14:32 | `approve_all`, ran visual QA |
+| Completed | 14:35 | `done.json` written, `human_checkpoints: 1`, 152s wall-clock |
+
+Final `done.json` status was `"escalated"` because visual QA scored 43/100 — it judged the output didn't match research-report specs. That's honest: with HITL, you'd have used `"action": "skip_to_finalize"` at the LaTeX checkpoint to ship without visual QA running. That's the use case HITL exists for.
+
+## Known issues surfaced (pre-existing, not HITL bugs)
+
+1. **`compilation_success: false` in ask.json `notes` when PDF clearly compiled.** When the LLM-fix branch in `latex_optimization_node` (lines ~507-538 of `langgraph_workflow.py`) succeeds, it doesn't update `agent_context["latex_specialist_notes"]["compilation_success"]`. Cosmetic but misleading. Small, isolated fix.
+2. **Visual QA "Version v3_visual_qa_iter1 already exists"** during resume. Pre-existing version-manager interaction in `agents/visual_qa/agent.py`. Didn't crash the run; the run still completed. Worth filing as a separate bug.
+3. **Windows UTF-8 console** — fixed in `8bedf6e`. The autonomous CLI worked around this via `run_agent.py`; the new entry point now handles it itself.
+
+## Try it yourself
+
+Prerequisites: `pip install -e ".[dev]"` (or use the `.venv-regression/` venv we set up locally), MiKTeX/TeX Live for PDF compilation, `ANTHROPIC_API_KEY` in `.env`.
+
+```powershell
+# Auto-approve mode — drives the run end-to-end with canned approvals
+python -m printshop start abc12345 --content-type research_report --auto-approve
+
+# Manual HITL — pauses at each checkpoint, you craft response.json
+python -m printshop start xyz99999 --content-type research_report
+python -m printshop status xyz99999          # → state: "paused"
+cat ~/.printshop/runs/xyz99999/ask.json      # → score, paths, valid_actions
+
+# Write response.json with {"action": "approve_all", "schema_version": "1"}
+python -m printshop resume xyz99999 --response ~/.printshop/runs/xyz99999/response.json
+python -m printshop logs xyz99999            # → all events
+```
+
+Other commands: `printshop list`, `printshop abort <id>`.
+
+## Roadmap (priority order)
+
+1. ~~**Push branch + open draft PR**~~ — pushed; draft PR optional.
+2. **Add interrupts at content_review and visual_qa stages.** Currently only LaTeX has a HITL pause. The user should be able to steer all three stages. Pattern is established — copy the `human_checkpoint_after_latex_node` shape, parameterize by stage. ~30 lines per stage + tests.
+3. **Fix `compilation_success` reporting in `latex_optimization_node`.** Small, isolated. While we're touching that node, also fix the visual_qa version collision (item 2 in known issues).
+4. **Build Docker engine image.** Move the runtime into a container; expose CLI via `docker exec`. Bind mount `~/.printshop/runs/` so artifacts are visible on host.
+5. **Sketch the Claude Code plugin.** `commands/printshop.md`, `commands/printshop-iterate.md`, `commands/printshop-resume.md`, content-type-* skills (Claude-side, for input prep). The earlier sketch in conversation is the starting point.
+6. **`/loop /printshop-iterate` polling.** The plugin uses `/loop` to poll `printshop status` between human turns; only summons the human when `state == "paused"`.
+
+## What's intentionally NOT in this commit
+
+- No Docker engine yet — engine still runs in-process via local Python.
+- No Claude Code plugin manifest, commands, or skills.
+- No `printshop-engine` console script — invocation is `python -m printshop` to avoid colliding with the existing `printshop` script that points at `agents.qa_orchestrator.agent:main` (the autonomous CLI).
+- Only one HITL pause point (post-LaTeX). Pre-LaTeX content review and post-visual-QA checkpoints come incrementally.
+- No surgical-diff LLM call yet for `additional_instructions`. The `approve_all` and `abort` paths work; `approve_subset` and `describe` ride through routing today but don't actually apply additional_instructions until that LLM call lands. Worth doing alongside item 2.
+
+## Files to know
+
+| File | Purpose |
+|---|---|
+| `printshop/cli.py` | Entry point, subcommand dispatch, JSON I/O |
+| `printshop/contracts.py` | Schema, payload builders, `runs_dir()` |
+| `agents/qa_orchestrator/langgraph_workflow.py` | HITL flag, interrupt node, routing wrapper |
+| `tests/test_hitl_cli.py` | 48 tests for everything HITL-specific |
+| `~/.printshop/runs/<id>/` | Per-run state (configurable via `PRINTSHOP_RUNS_DIR`) |

--- a/printshop/__init__.py
+++ b/printshop/__init__.py
@@ -1,0 +1,28 @@
+"""HITL-capable engine CLI for deepagents-printshop.
+
+Wraps the LangGraph QA pipeline with start/resume/status commands. Each run
+lives in a directory under ``PRINTSHOP_RUNS_DIR`` (defaults to
+``~/.printshop/runs``) and is paused/resumed via JSON marker files plus a
+LangGraph SQLite checkpoint.
+
+Activated by setting ``HITL_MODE=on`` in the engine environment; with the
+flag off, the pipeline runs autonomously as before.
+"""
+
+from printshop.contracts import (
+    AUTO_APPROVE_RESPONSE,
+    SCHEMA_VERSION,
+    build_ask_envelope,
+    build_done_payload,
+    build_error_payload,
+    runs_dir,
+)
+
+__all__ = [
+    "AUTO_APPROVE_RESPONSE",
+    "SCHEMA_VERSION",
+    "build_ask_envelope",
+    "build_done_payload",
+    "build_error_payload",
+    "runs_dir",
+]

--- a/printshop/__main__.py
+++ b/printshop/__main__.py
@@ -1,0 +1,6 @@
+"""Allow ``python -m printshop ...`` to invoke the CLI."""
+
+from printshop.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/printshop/cli.py
+++ b/printshop/cli.py
@@ -444,7 +444,35 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _force_utf8_stdio() -> None:
+    """Force UTF-8 on stdout/stderr so emoji and Unicode in agent ``print``
+    calls don't crash the run on Windows under cp1252.
+
+    Mirrors the wrapper in ``run_agent.py``. Idempotent and a no-op when
+    streams are already UTF-8.
+    """
+    import io
+
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    os.environ.setdefault("PYTHONUTF8", "1")
+
+    if sys.platform != "win32":
+        return
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name, None)
+        if stream is None:
+            continue
+        encoding = (getattr(stream, "encoding", "") or "").lower()
+        if "utf" in encoding:
+            continue
+        buffer = getattr(stream, "buffer", None)
+        if buffer is None:
+            continue
+        setattr(sys, name, io.TextIOWrapper(buffer, encoding="utf-8", errors="replace"))
+
+
 def main(argv: Optional[List[str]] = None) -> int:
+    _force_utf8_stdio()
     parser = _build_parser()
     args = parser.parse_args(argv)
     return args.func(args)

--- a/printshop/cli.py
+++ b/printshop/cli.py
@@ -1,0 +1,454 @@
+"""HITL-capable engine CLI.
+
+Usage::
+
+    python -m printshop start <run_id> --content-type research_report [--auto-approve]
+    python -m printshop resume <run_id> --response <path-to-response.json>
+    python -m printshop status <run_id>
+    python -m printshop list
+    python -m printshop abort <run_id>
+    python -m printshop logs <run_id>
+
+Each ``start`` and ``resume`` invocation runs the LangGraph QA pipeline until
+it pauses at an ``interrupt()`` or completes. State persists in
+``<runs_dir>/<run_id>/checkpoint.sqlite``; the CLI is stateless across calls.
+Marker files (``ask.json``, ``done.json``, ``error.json``) are the single
+source of truth for "what should the driver do next".
+
+Exit codes:
+* ``0`` paused at interrupt (success, awaiting human) OR completed
+* ``1`` engine error / unrecoverable failure
+* ``2`` invalid arguments
+* ``3`` run not found
+* ``4`` run not in a resumable state
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Ensure project root is importable when invoked via ``python -m printshop``
+# from inside the container or via the source tree.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from printshop.contracts import (  # noqa: E402, I001
+    AUTO_APPROVE_RESPONSE,
+    SCHEMA_VERSION,
+    build_ask_envelope,
+    build_done_payload,
+    build_error_payload,
+    is_valid_response,
+)
+from printshop.contracts import run_dir as _run_dir  # noqa: E402
+from printshop.contracts import runs_dir as _runs_dir  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# JSON I/O helpers
+# ---------------------------------------------------------------------------
+
+def _write_json_atomic(path: Path, data: Dict[str, Any]) -> None:
+    """Write JSON via temp+rename so a partial write never confuses a poller."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _append_event(run_dir: Path, event: str, **fields: Any) -> None:
+    """Append a single line to the run's events.log."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(
+        {"ts": datetime.now().isoformat(timespec="seconds"), "event": event, **fields},
+        default=str,
+    )
+    with open(run_dir / "events.log", "a", encoding="utf-8") as f:
+        f.write(line + "\n")
+
+
+def _clear_markers(run_dir: Path, *, keep: tuple = ()) -> None:
+    """Remove ask/response/done/error markers (selectively) before the next step."""
+    for name in ("ask.json", "response.json", "done.json", "error.json"):
+        if name in keep:
+            continue
+        marker = run_dir / name
+        marker.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Initial state
+# ---------------------------------------------------------------------------
+
+def _build_initial_state(run_id: str, content_type: str, output_dir: Path) -> Dict[str, Any]:
+    """Build the PipelineState dict the graph expects for a fresh run."""
+    return {
+        "workflow_id": run_id,
+        "content_source": content_type,
+        "starting_version": "v0_original",
+        "current_version": "v0_original",
+        "current_stage": "initialization",
+        "iterations_completed": 0,
+        "success": False,
+        "human_handoff": False,
+        "escalated": False,
+        "start_time": datetime.now().isoformat(timespec="seconds"),
+        "output_dir": str(output_dir),
+        "agent_results": [],
+        "quality_assessments": [],
+        "quality_evaluations": [],
+        "agent_context": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Graph compilation + invocation
+# ---------------------------------------------------------------------------
+
+def _ensure_hitl_on() -> None:
+    """Set HITL_MODE=on for the duration of this process if not already set.
+
+    The CLI is the contract between the human and the graph; without HITL
+    mode the graph would skip the interrupt nodes and run autonomously,
+    defeating the purpose of going through start/resume.
+    """
+    if (os.environ.get("HITL_MODE") or "").strip().lower() != "on":
+        os.environ["HITL_MODE"] = "on"
+
+
+def _extract_interrupt_payload(result: Any) -> Optional[Dict[str, Any]]:
+    """Pull the first pending interrupt's payload out of an invoke() result.
+
+    LangGraph 1.x surfaces pending interrupts as ``result["__interrupt__"]``
+    (a list of ``Interrupt`` objects with ``.value``). Returns ``None`` if no
+    interrupts are pending — meaning the graph reached an END node.
+    """
+    if not isinstance(result, dict):
+        return None
+    interrupts = result.get("__interrupt__")
+    if not interrupts:
+        return None
+    first = interrupts[0]
+    value = getattr(first, "value", None)
+    if isinstance(value, dict):
+        return value
+    if value is None and isinstance(first, dict):
+        return first.get("value") if isinstance(first.get("value"), dict) else first
+    return None
+
+
+def _invoke_graph(run_id: str, run_dir: Path, command_or_state: Any) -> int:
+    """Compile the graph with a SQLite checkpoint and invoke once.
+
+    Writes ask.json/done.json/error.json based on the outcome and returns the
+    matching exit code.
+    """
+    _ensure_hitl_on()
+
+    try:
+        from langgraph.checkpoint.sqlite import SqliteSaver
+
+        from agents.qa_orchestrator.langgraph_workflow import build_qa_graph
+    except Exception as exc:
+        _append_event(run_dir, "engine_import_failed", error=str(exc))
+        _write_json_atomic(run_dir / "error.json", build_error_payload(run_id, exc, stage="bootstrap"))
+        return 1
+
+    checkpoint_path = run_dir / "checkpoint.sqlite"
+    config = {"configurable": {"thread_id": run_id}}
+    started_at = time.monotonic()
+
+    try:
+        with SqliteSaver.from_conn_string(str(checkpoint_path)) as saver:
+            graph = build_qa_graph().compile(checkpointer=saver)
+            result = graph.invoke(command_or_state, config=config)
+    except BaseException as exc:  # pragma: no cover - defensive
+        _append_event(run_dir, "engine_invoke_failed", error=str(exc))
+        _write_json_atomic(run_dir / "error.json", build_error_payload(run_id, exc))
+        return 1
+
+    elapsed = time.monotonic() - started_at
+    payload = _extract_interrupt_payload(result)
+
+    if payload is not None:
+        envelope = build_ask_envelope(run_id, payload)
+        _write_json_atomic(run_dir / "ask.json", envelope)
+        _append_event(run_dir, "paused", stage=payload.get("stage"))
+        return 0
+
+    # Graph ran to END — completion or escalation, both terminal.
+    human_checkpoints = sum(
+        1 for line in _read_events(run_dir) if line.get("event") == "paused"
+    )
+    done = build_done_payload(
+        run_id,
+        result if isinstance(result, dict) else {},
+        wallclock_seconds=elapsed,
+        human_checkpoints=human_checkpoints,
+    )
+    _write_json_atomic(run_dir / "done.json", done)
+    _append_event(run_dir, "completed", elapsed=round(elapsed, 2))
+    return 0
+
+
+def _read_events(run_dir: Path) -> List[Dict[str, Any]]:
+    """Return all events from events.log; tolerates a missing file."""
+    log = run_dir / "events.log"
+    if not log.exists():
+        return []
+    out: List[Dict[str, Any]] = []
+    for line in log.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+def cmd_start(args: argparse.Namespace) -> int:
+    rd = _run_dir(args.run_id)
+    if rd.exists():
+        print(f"error: run {args.run_id!r} already exists at {rd}", file=sys.stderr)
+        return 2
+
+    rd.mkdir(parents=True, exist_ok=False)
+    output_dir = Path(args.output_dir) if args.output_dir else rd / "artifacts" / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    state = _build_initial_state(args.run_id, args.content_type, output_dir)
+    _append_event(rd, "started", content_type=args.content_type, schema_version=SCHEMA_VERSION)
+
+    rc = _invoke_graph(args.run_id, rd, state)
+
+    if args.auto_approve:
+        return _auto_approve_until_done(args.run_id, rd, rc, max_steps=args.auto_approve_max_steps)
+    return rc
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    rd = _run_dir(args.run_id)
+    if not rd.exists():
+        print(f"error: run {args.run_id!r} not found at {rd}", file=sys.stderr)
+        return 3
+
+    if (rd / "done.json").exists() or (rd / "error.json").exists():
+        print(f"error: run {args.run_id!r} is not in a resumable state", file=sys.stderr)
+        return 4
+
+    response_path = Path(args.response).expanduser()
+    if not response_path.exists():
+        print(f"error: response file not found: {response_path}", file=sys.stderr)
+        return 2
+
+    response = _read_json(response_path)
+    if not is_valid_response(response):
+        print("error: response.json missing/invalid 'action' (expected one of approve_all/etc.)", file=sys.stderr)
+        return 2
+
+    # Clear stale markers BEFORE invoking so a poll mid-resume sees no
+    # ask.json (i.e., state == running).
+    _clear_markers(rd, keep=())
+    _append_event(rd, "resumed", action=response.get("action"))
+
+    from langgraph.types import Command
+    return _invoke_graph(args.run_id, rd, Command(resume=response))
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    rd = _run_dir(args.run_id)
+    if not rd.exists():
+        print(json.dumps({"run_id": args.run_id, "state": "not_found"}))
+        return 3
+
+    if (rd / "error.json").exists():
+        state = "failed"
+    elif (rd / "done.json").exists():
+        state = "completed"
+    elif (rd / "ask.json").exists():
+        state = "paused"
+    else:
+        state = "running"
+
+    last_mtime: Optional[str] = None
+    try:
+        latest = max(
+            (p for p in rd.iterdir() if p.is_file()),
+            key=lambda p: p.stat().st_mtime,
+            default=None,
+        )
+        if latest is not None:
+            last_mtime = datetime.fromtimestamp(latest.stat().st_mtime).isoformat(timespec="seconds")
+    except OSError:
+        pass
+
+    print(json.dumps({
+        "run_id": args.run_id,
+        "state": state,
+        "last_event_at": last_mtime,
+        "ask_path": str(rd / "ask.json") if state == "paused" else None,
+        "done_path": str(rd / "done.json") if state == "completed" else None,
+        "error_path": str(rd / "error.json") if state == "failed" else None,
+    }))
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    root = _runs_dir()
+    if not root.exists():
+        print("(no runs)")
+        return 0
+    rows = []
+    for rd in sorted(root.iterdir()):
+        if not rd.is_dir():
+            continue
+        if (rd / "error.json").exists():
+            state = "failed"
+        elif (rd / "done.json").exists():
+            state = "completed"
+        elif (rd / "ask.json").exists():
+            state = "paused"
+        else:
+            state = "running"
+        try:
+            mtime = datetime.fromtimestamp(rd.stat().st_mtime).isoformat(timespec="seconds")
+        except OSError:
+            mtime = "?"
+        rows.append((rd.name, state, mtime))
+    if not rows:
+        print("(no runs)")
+        return 0
+    width = max(len(r[0]) for r in rows)
+    for name, state, mtime in rows:
+        print(f"{name:<{width}}  {state:<10}  {mtime}")
+    return 0
+
+
+def cmd_abort(args: argparse.Namespace) -> int:
+    rd = _run_dir(args.run_id)
+    if not rd.exists():
+        print(f"error: run {args.run_id!r} not found", file=sys.stderr)
+        return 3
+    err = build_error_payload(args.run_id, RuntimeError("aborted by user"), stage="abort")
+    err["status"] = "aborted"
+    _write_json_atomic(rd / "error.json", err)
+    _clear_markers(rd, keep=("error.json",))
+    _append_event(rd, "aborted")
+    print(json.dumps({"run_id": args.run_id, "state": "aborted"}))
+    return 0
+
+
+def cmd_logs(args: argparse.Namespace) -> int:
+    rd = _run_dir(args.run_id)
+    if not rd.exists():
+        print(f"error: run {args.run_id!r} not found", file=sys.stderr)
+        return 3
+    log = rd / "events.log"
+    if not log.exists():
+        return 0
+    text = log.read_text(encoding="utf-8")
+    if args.tail:
+        lines = text.splitlines()[-args.tail:]
+        text = "\n".join(lines)
+    print(text)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# --auto-approve helper
+# ---------------------------------------------------------------------------
+
+def _auto_approve_until_done(run_id: str, rd: Path, initial_rc: int, *, max_steps: int) -> int:
+    """Repeatedly resume with AUTO_APPROVE_RESPONSE until done/error/limit.
+
+    Used by ``printshop start --auto-approve`` and by regression tests so a
+    fresh run can complete end-to-end without a human in the loop.
+    """
+    rc = initial_rc
+    steps = 0
+    while rc == 0 and (rd / "ask.json").exists() and steps < max_steps:
+        steps += 1
+        response_path = rd / "_auto_approve_response.json"
+        _write_json_atomic(response_path, AUTO_APPROVE_RESPONSE)
+
+        ns = argparse.Namespace(run_id=run_id, response=str(response_path))
+        rc = cmd_resume(ns)
+        response_path.unlink(missing_ok=True)
+
+    if rc == 0 and (rd / "ask.json").exists():
+        # Hit the step cap with a pending interrupt — surface as escalation
+        # rather than silently leaving the run paused forever.
+        msg = f"--auto-approve hit max_steps={max_steps} with the run still paused"
+        _append_event(rd, "auto_approve_capped", steps=steps)
+        _write_json_atomic(rd / "error.json", build_error_payload(run_id, RuntimeError(msg), stage="auto_approve"))
+        _clear_markers(rd, keep=("error.json",))
+        return 1
+    return rc
+
+
+# ---------------------------------------------------------------------------
+# argparse wiring
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="printshop", description="HITL engine CLI for deepagents-printshop.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("start", help="Start a new run; advance to first interrupt or completion.")
+    s.add_argument("run_id")
+    s.add_argument("--content-type", required=True, dest="content_type")
+    s.add_argument("--output-dir", dest="output_dir", default=None)
+    s.add_argument("--auto-approve", action="store_true", dest="auto_approve",
+                   help="Drive the run end-to-end with canned approve_all responses (regression mode).")
+    s.add_argument("--auto-approve-max-steps", type=int, default=20, dest="auto_approve_max_steps")
+    s.set_defaults(func=cmd_start)
+
+    s = sub.add_parser("resume", help="Resume a paused run with a response.json.")
+    s.add_argument("run_id")
+    s.add_argument("--response", required=True)
+    s.set_defaults(func=cmd_resume)
+
+    s = sub.add_parser("status", help="Print current state of a run as JSON.")
+    s.add_argument("run_id")
+    s.set_defaults(func=cmd_status)
+
+    s = sub.add_parser("list", help="List all runs in the runs directory.")
+    s.set_defaults(func=cmd_list)
+
+    s = sub.add_parser("abort", help="Mark a run as failed/aborted.")
+    s.add_argument("run_id")
+    s.set_defaults(func=cmd_abort)
+
+    s = sub.add_parser("logs", help="Print a run's event log.")
+    s.add_argument("run_id")
+    s.add_argument("--tail", type=int, default=None)
+    s.set_defaults(func=cmd_logs)
+
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/printshop/contracts.py
+++ b/printshop/contracts.py
@@ -1,0 +1,144 @@
+"""JSON contract schemas and helpers for the printshop HITL CLI.
+
+The CLI and any external driver (Claude Code plugin, regression harness)
+exchange state via JSON files in the run directory:
+
+* ``ask.json`` — engine → driver, present while the graph is paused at an
+  interrupt; carries the payload the human should react to
+* ``response.json`` — driver → engine, present briefly while ``resume`` runs;
+  carries the human's decision
+* ``done.json`` — engine → driver, present when the graph terminates cleanly
+* ``error.json`` — engine → driver, present when a stage failed unrecoverably
+
+All payloads carry ``schema_version`` so old drivers fail loud against new
+engines instead of silently misinterpreting fields.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+SCHEMA_VERSION = "1"
+
+# Canned response used by ``printshop start --auto-approve`` and regression
+# tests. Mirrors the action vocabulary the LangGraph routing function expects.
+AUTO_APPROVE_RESPONSE: Dict[str, Any] = {
+    "schema_version": SCHEMA_VERSION,
+    "action": "approve_all",
+    "approved_proposal_ids": [],
+    "rejected_proposal_ids": [],
+    "additional_instructions": "",
+    "human_score": None,
+    "exit_after_apply": False,
+}
+
+VALID_ACTIONS = {
+    "approve_all",
+    "approve_subset",
+    "edit",
+    "describe",
+    "rerun_stage",
+    "skip_to_finalize",
+    "abort",
+}
+
+
+def runs_dir() -> Path:
+    """Resolve the directory that holds per-run state.
+
+    Order: ``PRINTSHOP_RUNS_DIR`` env var → ``/runs`` (when present, the
+    container bind-mount target) → ``~/.printshop/runs``.
+    """
+    env = os.environ.get("PRINTSHOP_RUNS_DIR")
+    if env:
+        return Path(env).expanduser()
+    container_runs = Path("/runs")
+    if container_runs.exists() and container_runs.is_dir():
+        return container_runs
+    return Path.home() / ".printshop" / "runs"
+
+
+def run_dir(run_id: str) -> Path:
+    """Path to a specific run's directory under the runs root."""
+    return runs_dir() / run_id
+
+
+def build_ask_envelope(run_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Wrap a node-supplied interrupt payload with envelope fields.
+
+    Node payloads carry stage-specific content (artifacts, scores, proposals,
+    etc.). This helper adds ``schema_version`` and ``run_id`` so the file the
+    driver reads is self-contained.
+    """
+    envelope = {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "asked_at": datetime.now().isoformat(timespec="seconds"),
+    }
+    envelope.update(payload or {})
+    return envelope
+
+
+def build_done_payload(
+    run_id: str,
+    final_state: Dict[str, Any],
+    *,
+    wallclock_seconds: Optional[float] = None,
+    human_checkpoints: int = 0,
+) -> Dict[str, Any]:
+    """Build the done.json payload from the graph's final state."""
+    output_dir = final_state.get("output_dir", "artifacts/output")
+    content_source = final_state.get("content_source", "research_report")
+
+    stages_completed = sorted({
+        r.get("agent_type")
+        for r in (final_state.get("agent_results") or [])
+        if r.get("success")
+    } - {None})
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "status": "completed" if final_state.get("success") else "escalated",
+        "final_artifacts": {
+            "tex": f"{output_dir}/{content_source}.tex",
+            "pdf": f"{output_dir}/{content_source}.pdf",
+        },
+        "stages_completed": stages_completed,
+        "iterations_completed": final_state.get("iterations_completed", 0),
+        "human_checkpoints": human_checkpoints,
+        "escalated": bool(final_state.get("escalated")),
+        "wallclock_seconds": wallclock_seconds,
+        "completed_at": datetime.now().isoformat(timespec="seconds"),
+    }
+
+
+def build_error_payload(
+    run_id: str,
+    error: BaseException,
+    *,
+    stage: Optional[str] = None,
+    last_artifacts: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Build the error.json payload for an unrecoverable failure."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "status": "failed",
+        "stage": stage,
+        "error_type": type(error).__name__,
+        "error": str(error),
+        "last_artifacts": last_artifacts or {},
+        "failed_at": datetime.now().isoformat(timespec="seconds"),
+    }
+
+
+def is_valid_response(response: Dict[str, Any]) -> bool:
+    """Quick shape check on a response payload before feeding it to the graph."""
+    if not isinstance(response, dict):
+        return False
+    action = response.get("action")
+    return action in VALID_ACTIONS

--- a/tests/test_hitl_cli.py
+++ b/tests/test_hitl_cli.py
@@ -1,0 +1,498 @@
+"""Tests for the HITL engine CLI and its LangGraph wiring.
+
+No Docker, TeX Live, or API keys required. The graph itself is exercised
+elsewhere (test_langgraph_workflow.py); these tests cover only the
+HITL-specific additions: the HITL_MODE flag, the human-checkpoint node and
+its routing, the JSON contracts, and the CLI's filesystem-only subcommands.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Project root on sys.path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agents.qa_orchestrator.langgraph_workflow import (  # noqa: E402, I001
+    _build_latex_checkpoint_payload,
+    build_qa_graph,
+    get_hitl_mode,
+    route_after_human_checkpoint,
+    route_after_latex_optimization_or_hitl,
+)
+from agents.qa_orchestrator.quality_gates import (  # noqa: E402
+    QualityAssessment,
+    QualityGateEvaluation,
+    QualityGateResult,
+)
+from printshop.cli import (  # noqa: E402, I001
+    _build_initial_state,
+    _build_parser,
+    _extract_interrupt_payload,
+    cmd_abort,
+    cmd_list,
+    cmd_status,
+)
+from printshop.contracts import (  # noqa: E402
+    AUTO_APPROVE_RESPONSE,
+    SCHEMA_VERSION,
+    build_ask_envelope,
+    build_done_payload,
+    build_error_payload,
+    is_valid_response,
+    run_dir,
+    runs_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# HITL flag
+# ---------------------------------------------------------------------------
+
+class TestHitlFlag:
+    def test_default_is_off(self, monkeypatch):
+        monkeypatch.delenv("HITL_MODE", raising=False)
+        assert get_hitl_mode() is False
+
+    def test_on_lowercase(self, monkeypatch):
+        monkeypatch.setenv("HITL_MODE", "on")
+        assert get_hitl_mode() is True
+
+    def test_on_mixed_case(self, monkeypatch):
+        monkeypatch.setenv("HITL_MODE", "ON")
+        assert get_hitl_mode() is True
+
+    def test_on_with_whitespace(self, monkeypatch):
+        monkeypatch.setenv("HITL_MODE", "  on  ")
+        assert get_hitl_mode() is True
+
+    def test_garbage_is_off(self, monkeypatch):
+        monkeypatch.setenv("HITL_MODE", "yes")
+        assert get_hitl_mode() is False
+
+
+# ---------------------------------------------------------------------------
+# Routing: HITL on
+# ---------------------------------------------------------------------------
+
+def _state_with_latex_result(*, success: bool, score: int = 90):
+    return {
+        "content_source": "research_report",
+        "agent_results": [{
+            "agent_type": "latex_specialist",
+            "success": success,
+            "version_created": "v2_latex_optimized",
+            "quality_score": score if success else None,
+            "processing_time": 1.0,
+            "issues_found": [] if success else ["PDF_COMPILATION_FAILED: oops"],
+            "optimizations_applied": [],
+        }],
+        "quality_assessments": [],
+        "quality_evaluations": [],
+        "iterations_completed": 0,
+        "agent_context": {},
+    }
+
+
+class TestRouteAfterLatexOrHitl:
+    def test_hitl_off_defers_to_existing_routing(self, monkeypatch):
+        """With HITL off, the wrapper must delegate to route_after_latex_optimization."""
+        monkeypatch.delenv("HITL_MODE", raising=False)
+        with patch("agents.qa_orchestrator.langgraph_workflow.WorkflowCoordinator") as MockCoord:
+            mock = MagicMock()
+            mock.assess_workflow_quality.return_value = QualityAssessment(latex_score=90)
+            mock.quality_gate_manager.evaluate_latex_quality_gate.return_value = QualityGateEvaluation(
+                gate_name="latex_quality", result=QualityGateResult.PASS, score=90, threshold=85,
+                reasons=[], recommendations=[], next_action="proceed_to_visual_qa",
+            )
+            MockCoord.return_value = mock
+            assert route_after_latex_optimization_or_hitl(_state_with_latex_result(success=True)) == "enrich_for_visual_qa"
+
+    def test_hitl_on_with_success_routes_to_checkpoint(self, monkeypatch):
+        monkeypatch.setenv("HITL_MODE", "on")
+        result = route_after_latex_optimization_or_hitl(_state_with_latex_result(success=True))
+        assert result == "human_checkpoint_after_latex"
+
+    def test_hitl_on_with_failure_defers(self, monkeypatch):
+        """Compilation failure should still drive the auto-retry path even when HITL is on."""
+        monkeypatch.setenv("HITL_MODE", "on")
+        with patch("agents.qa_orchestrator.langgraph_workflow.WorkflowCoordinator") as MockCoord:
+            mock = MagicMock()
+            mock.assess_workflow_quality.return_value = QualityAssessment(latex_score=50)
+            mock.quality_gate_manager.evaluate_latex_quality_gate.return_value = QualityGateEvaluation(
+                gate_name="latex_quality", result=QualityGateResult.ITERATE, score=50, threshold=85,
+                reasons=[], recommendations=[], next_action="run_latex_specialist",
+            )
+            mock.quality_gate_manager.thresholds.max_iterations = 3
+            MockCoord.return_value = mock
+            result = route_after_latex_optimization_or_hitl(_state_with_latex_result(success=False))
+            assert result in ("iteration", "escalation")
+            assert result != "human_checkpoint_after_latex"
+
+    def test_hitl_on_no_latex_results_defers(self, monkeypatch):
+        """Edge: if no latex_specialist result is present, defer to autonomous routing."""
+        monkeypatch.setenv("HITL_MODE", "on")
+        with patch("agents.qa_orchestrator.langgraph_workflow.WorkflowCoordinator") as MockCoord:
+            mock = MagicMock()
+            mock.assess_workflow_quality.return_value = QualityAssessment(latex_score=0)
+            mock.quality_gate_manager.evaluate_latex_quality_gate.return_value = QualityGateEvaluation(
+                gate_name="latex_quality", result=QualityGateResult.ITERATE, score=0, threshold=85,
+                reasons=[], recommendations=[], next_action="run_latex_specialist",
+            )
+            mock.quality_gate_manager.thresholds.max_iterations = 3
+            MockCoord.return_value = mock
+            state = _state_with_latex_result(success=True)
+            state["agent_results"] = []
+            result = route_after_latex_optimization_or_hitl(state)
+            assert result != "human_checkpoint_after_latex"
+
+
+# ---------------------------------------------------------------------------
+# Routing: from human checkpoint
+# ---------------------------------------------------------------------------
+
+def _state_with_response(action: str):
+    return {
+        "content_source": "research_report",
+        "agent_context": {"human_response_after_latex": {"action": action}},
+        "agent_results": [],
+        "quality_assessments": [],
+        "quality_evaluations": [],
+        "iterations_completed": 0,
+    }
+
+
+class TestRouteAfterHumanCheckpoint:
+    def test_abort_routes_to_escalation(self):
+        assert route_after_human_checkpoint(_state_with_response("abort")) == "escalation"
+
+    def test_rerun_stage_routes_to_iteration(self):
+        assert route_after_human_checkpoint(_state_with_response("rerun_stage")) == "iteration"
+
+    def test_skip_to_finalize_routes_to_completion(self):
+        assert route_after_human_checkpoint(_state_with_response("skip_to_finalize")) == "completion"
+
+    def test_approve_all_routes_to_visual_qa_when_auto(self, monkeypatch):
+        monkeypatch.delenv("VISUAL_QA_MODE", raising=False)
+        assert route_after_human_checkpoint(_state_with_response("approve_all")) == "enrich_for_visual_qa"
+
+    def test_approve_all_skips_visual_qa_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("VISUAL_QA_MODE", "disabled")
+        assert route_after_human_checkpoint(_state_with_response("approve_all")) == "quality_assessment"
+
+    def test_unknown_action_falls_through(self, monkeypatch):
+        monkeypatch.delenv("VISUAL_QA_MODE", raising=False)
+        assert route_after_human_checkpoint(_state_with_response("nonsense")) == "enrich_for_visual_qa"
+
+    def test_missing_response_defaults_to_proceed(self, monkeypatch):
+        monkeypatch.delenv("VISUAL_QA_MODE", raising=False)
+        state = {"agent_context": {}, "iterations_completed": 0}
+        assert route_after_human_checkpoint(state) == "enrich_for_visual_qa"
+
+
+# ---------------------------------------------------------------------------
+# Ask payload
+# ---------------------------------------------------------------------------
+
+class TestLatexCheckpointPayload:
+    def test_payload_shape(self):
+        state = {
+            "content_source": "research_report",
+            "output_dir": "/tmp/out",
+            "iterations_completed": 1,
+            "agent_results": [{
+                "agent_type": "latex_specialist",
+                "success": True,
+                "version_created": "v2_latex_optimized",
+                "quality_score": 88,
+                "processing_time": 1.0,
+                "issues_found": [],
+                "optimizations_applied": [],
+            }],
+            "agent_context": {
+                "latex_specialist_notes": {
+                    "structure_score": 23,
+                    "typography_score": 22,
+                    "typography_issues": ["minor: heading spacing"],
+                    "compilation_success": True,
+                },
+            },
+        }
+        p = _build_latex_checkpoint_payload(state)
+        assert p["stage"] == "latex_optimization"
+        assert p["iteration"] == 1
+        assert p["scores"]["agent"]["value"] == 88
+        assert p["artifacts"]["pdf"] == "/tmp/out/research_report.pdf"
+        assert p["artifacts"]["tex"] == "/tmp/out/research_report.tex"
+        assert "approve_all" in p["valid_actions"]
+        assert p["notes"]["typography_issues"] == ["minor: heading spacing"]
+
+
+# ---------------------------------------------------------------------------
+# Graph wiring
+# ---------------------------------------------------------------------------
+
+class TestGraphIncludesCheckpoint:
+    def test_human_checkpoint_node_present(self):
+        graph = build_qa_graph()
+        compiled = graph.compile()
+        assert "human_checkpoint_after_latex" in compiled.get_graph().nodes
+
+
+# ---------------------------------------------------------------------------
+# Contracts
+# ---------------------------------------------------------------------------
+
+class TestContracts:
+    def test_auto_approve_shape(self):
+        assert AUTO_APPROVE_RESPONSE["action"] == "approve_all"
+        assert AUTO_APPROVE_RESPONSE["schema_version"] == SCHEMA_VERSION
+        assert is_valid_response(AUTO_APPROVE_RESPONSE)
+
+    def test_is_valid_response_rejects_unknown_action(self):
+        assert not is_valid_response({"action": "nuke_it"})
+
+    def test_is_valid_response_rejects_missing_action(self):
+        assert not is_valid_response({})
+
+    def test_is_valid_response_rejects_non_dict(self):
+        assert not is_valid_response("approve_all")
+
+    def test_build_ask_envelope_adds_metadata(self):
+        env = build_ask_envelope("abc12345", {"stage": "latex_optimization", "question": "?"})
+        assert env["schema_version"] == SCHEMA_VERSION
+        assert env["run_id"] == "abc12345"
+        assert env["stage"] == "latex_optimization"
+        assert "asked_at" in env
+
+    def test_build_done_payload_basic(self):
+        final = {
+            "content_source": "research_report",
+            "output_dir": "/tmp/out",
+            "success": True,
+            "iterations_completed": 2,
+            "agent_results": [
+                {"agent_type": "content_editor", "success": True},
+                {"agent_type": "latex_specialist", "success": True},
+            ],
+        }
+        d = build_done_payload("xyz", final, wallclock_seconds=10.5, human_checkpoints=2)
+        assert d["status"] == "completed"
+        assert d["run_id"] == "xyz"
+        assert d["wallclock_seconds"] == 10.5
+        assert d["human_checkpoints"] == 2
+        assert "content_editor" in d["stages_completed"]
+        assert "latex_specialist" in d["stages_completed"]
+        assert d["final_artifacts"]["pdf"] == "/tmp/out/research_report.pdf"
+
+    def test_build_done_payload_escalated(self):
+        d = build_done_payload("xyz", {"escalated": True, "success": False}, human_checkpoints=0)
+        assert d["status"] == "escalated"
+        assert d["escalated"] is True
+
+    def test_build_error_payload(self):
+        e = build_error_payload("xyz", ValueError("boom"), stage="latex_optimization")
+        assert e["status"] == "failed"
+        assert e["stage"] == "latex_optimization"
+        assert e["error_type"] == "ValueError"
+        assert e["error"] == "boom"
+
+
+# ---------------------------------------------------------------------------
+# Initial state builder
+# ---------------------------------------------------------------------------
+
+class TestInitialState:
+    def test_initial_state_shape(self, tmp_path):
+        s = _build_initial_state("abc", "research_report", tmp_path)
+        assert s["workflow_id"] == "abc"
+        assert s["content_source"] == "research_report"
+        assert s["starting_version"] == "v0_original"
+        assert s["iterations_completed"] == 0
+        assert s["agent_results"] == []
+        assert s["agent_context"] == {}
+        assert s["output_dir"] == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Interrupt payload extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractInterruptPayload:
+    def test_no_interrupt(self):
+        assert _extract_interrupt_payload({"foo": "bar"}) is None
+
+    def test_empty_interrupt_list(self):
+        assert _extract_interrupt_payload({"__interrupt__": []}) is None
+
+    def test_extracts_value_attribute(self):
+        class FakeInterrupt:
+            value = {"stage": "latex_optimization", "question": "?"}
+        result = _extract_interrupt_payload({"__interrupt__": [FakeInterrupt()]})
+        assert result == {"stage": "latex_optimization", "question": "?"}
+
+    def test_non_dict_result_returns_none(self):
+        assert _extract_interrupt_payload("not a dict") is None
+
+
+# ---------------------------------------------------------------------------
+# CLI argparse
+# ---------------------------------------------------------------------------
+
+class TestParser:
+    def test_start_requires_content_type(self):
+        parser = _build_parser()
+        # Missing --content-type should error
+        with patch("sys.stderr"):
+            try:
+                parser.parse_args(["start", "abc"])
+            except SystemExit as e:
+                assert e.code != 0
+
+    def test_start_with_auto_approve(self):
+        args = _build_parser().parse_args(["start", "abc", "--content-type", "research_report", "--auto-approve"])
+        assert args.cmd == "start"
+        assert args.run_id == "abc"
+        assert args.content_type == "research_report"
+        assert args.auto_approve is True
+        assert args.auto_approve_max_steps == 20
+
+    def test_resume_requires_response(self):
+        parser = _build_parser()
+        with patch("sys.stderr"):
+            try:
+                parser.parse_args(["resume", "abc"])
+            except SystemExit as e:
+                assert e.code != 0
+
+    def test_status_minimal(self):
+        args = _build_parser().parse_args(["status", "abc"])
+        assert args.cmd == "status"
+        assert args.run_id == "abc"
+
+
+# ---------------------------------------------------------------------------
+# CLI status/list/abort against tmp runs dir
+# ---------------------------------------------------------------------------
+
+def _make_run(root: Path, name: str, *, ask=False, done=False, error=False):
+    rd = root / name
+    rd.mkdir(parents=True, exist_ok=True)
+    if ask:
+        (rd / "ask.json").write_text("{}", encoding="utf-8")
+    if done:
+        (rd / "done.json").write_text("{}", encoding="utf-8")
+    if error:
+        (rd / "error.json").write_text("{}", encoding="utf-8")
+    return rd
+
+
+class TestCliStatusListAbort:
+    def test_status_running(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        _make_run(tmp_path, "run1")
+        rc = cmd_status(MagicMock(run_id="run1"))
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["state"] == "running"
+
+    def test_status_paused(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        _make_run(tmp_path, "run1", ask=True)
+        cmd_status(MagicMock(run_id="run1"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["state"] == "paused"
+        assert out["ask_path"] is not None
+
+    def test_status_completed(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        _make_run(tmp_path, "run1", done=True)
+        cmd_status(MagicMock(run_id="run1"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["state"] == "completed"
+        assert out["done_path"] is not None
+
+    def test_status_failed(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        _make_run(tmp_path, "run1", error=True)
+        cmd_status(MagicMock(run_id="run1"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["state"] == "failed"
+
+    def test_status_failed_takes_precedence_over_done(self, tmp_path, monkeypatch, capsys):
+        """If both error.json and done.json exist (shouldn't normally), error wins."""
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        _make_run(tmp_path, "run1", done=True, error=True)
+        cmd_status(MagicMock(run_id="run1"))
+        out = json.loads(capsys.readouterr().out)
+        assert out["state"] == "failed"
+
+    def test_status_not_found(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        rc = cmd_status(MagicMock(run_id="nope"))
+        assert rc == 3
+        out = json.loads(capsys.readouterr().out)
+        assert out["state"] == "not_found"
+
+    def test_list_empty(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        rc = cmd_list(MagicMock())
+        assert rc == 0
+        assert "no runs" in capsys.readouterr().out
+
+    def test_list_with_runs(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        _make_run(tmp_path, "alpha", ask=True)
+        _make_run(tmp_path, "beta", done=True)
+        cmd_list(MagicMock())
+        out = capsys.readouterr().out
+        assert "alpha" in out and "paused" in out
+        assert "beta" in out and "completed" in out
+
+    def test_abort_marks_failed(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        rd = _make_run(tmp_path, "run1", ask=True)
+        rc = cmd_abort(MagicMock(run_id="run1"))
+        assert rc == 0
+        assert (rd / "error.json").exists()
+        assert not (rd / "ask.json").exists()
+        err = json.loads((rd / "error.json").read_text())
+        assert err["status"] == "aborted"
+
+    def test_abort_unknown_run(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        with patch("sys.stderr"):
+            assert cmd_abort(MagicMock(run_id="nope")) == 3
+
+
+# ---------------------------------------------------------------------------
+# Runs dir resolution
+# ---------------------------------------------------------------------------
+
+class TestRunsDir:
+    def test_env_var_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        assert runs_dir() == tmp_path
+
+    def test_run_dir_joins_run_id(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PRINTSHOP_RUNS_DIR", str(tmp_path))
+        assert run_dir("abc12345") == tmp_path / "abc12345"
+
+    def test_default_falls_back_to_home(self, monkeypatch):
+        monkeypatch.delenv("PRINTSHOP_RUNS_DIR", raising=False)
+        # Patch /runs check to fail
+        with patch("printshop.contracts.Path") as MockPath:
+            # When called as Path("/runs"), return a fake that doesn't exist
+            def path_factory(arg):
+                if arg == "/runs":
+                    fake = MagicMock()
+                    fake.exists.return_value = False
+                    return fake
+                return Path(arg)
+            MockPath.side_effect = path_factory
+            MockPath.home.return_value = Path("/fake/home")
+            result = runs_dir()
+            assert ".printshop" in str(result) and "runs" in str(result)

--- a/tests/test_langgraph_workflow.py
+++ b/tests/test_langgraph_workflow.py
@@ -65,14 +65,15 @@ class TestGraphCompilation:
         ]:
             assert node in mermaid, f"Node '{node}' missing from Mermaid diagram"
 
-    def test_graph_has_10_nodes(self):
-        """Graph should have 10 nodes (7 processing + 3 enrichment)."""
+    def test_graph_has_11_nodes(self):
+        """Graph should have 11 nodes (7 processing + 3 enrichment + 1 HITL checkpoint)."""
         graph = build_qa_graph()
         compiled = graph.compile()
         node_names = set(compiled.get_graph().nodes.keys())
         # LangGraph adds __start__ and __end__ pseudo-nodes
         real_nodes = node_names - {"__start__", "__end__"}
-        assert len(real_nodes) == 10, f"Expected 10 nodes, got {len(real_nodes)}: {real_nodes}"
+        assert len(real_nodes) == 11, f"Expected 11 nodes, got {len(real_nodes)}: {real_nodes}"
+        assert "human_checkpoint_after_latex" in real_nodes
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Opt-in human-in-the-loop control surface for the QA pipeline. With `HITL_MODE=on`, the LangGraph workflow pauses at a new `human_checkpoint_after_latex` node via `interrupt()`; with the flag off (default), routing is byte-identical to today.
- New `printshop/` package: `start`, `resume`, `status`, `list`, `abort`, `logs` — driven through JSON marker files (`ask.json` / `response.json` / `done.json` / `error.json`) in `~/.printshop/runs/<run_id>/` (override with `PRINTSHOP_RUNS_DIR`). LangGraph SQLite checkpoint persists across separate Python invocations.
- `--auto-approve` on `printshop start` so regression runs and CI can drive the loop end-to-end with canned `approve_all` responses.
- Full design rationale, JSON contract reference, smoke-test results, and prioritized roadmap in [`docs/hitl-engine-handoff.md`](docs/hitl-engine-handoff.md).

This is the **engine half** of a larger move toward shipping the runtime in Docker and the user flow as a Claude Code plugin. No plugin manifest, no Docker image, no console-script changes in this PR — those are follow-ups against the contract this lands.

## Test plan

- [x] 48 new tests in `tests/test_hitl_cli.py` cover the flag, routing in both modes, ask payload, contract envelopes, CLI subcommands, and `--auto-approve` plumbing
- [x] Existing graph-node-count test bumped from 10 → 11
- [x] Full test suite passes locally (137 passed)
- [x] `ruff check .` clean
- [x] End-to-end smoke test on Windows + MiKTeX with a real `research_report` run (run id `d4e2aac2`): paused at LaTeX checkpoint with score 93/100, resumed with `approve_all`, completed in 152s — full timeline in the handoff doc
- [ ] Verify CI passes
- [ ] Verify on macOS / Linux (Windows-specific UTF-8 reconfig is a no-op there but worth a sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)